### PR TITLE
test: add integration test for W2001 (unused import)

### DIFF
--- a/integration-tests/pass/warnings/W2001_unused_import.ez
+++ b/integration-tests/pass/warnings/W2001_unused_import.ez
@@ -1,0 +1,10 @@
+/*
+ * Warning Test: W2001 - unused import
+ * Expected: warning[W2001]
+ */
+
+import @math
+
+do main() {
+    println("hello")
+}


### PR DESCRIPTION
## 📝 Description
Added a new integration test for warning code W2001 (unused import) in the integration-tests/pass/warnings/ folder.

## 🔗 Related Issue
Closes #1568


## 🎯 Type of Change
- [x] `test`: Test update (adding missing tests or correcting existing tests)

## ✅ Pre-Submission Checklist
- [x] My commit messages follow the Conventional Commits format
- [x] This PR is against the `main` branch 

## 🧪 How Has This Been Tested?
Created the `W2001_unused_import.ez` file with a minimal program that imports a module without using it to trigger the W2001 warning.