### PR TITLE
feat(cli): add -o/--output flag to ez doc

### DIFF
--- a/cmd/ez/commands.go
+++ b/cmd/ez/commands.go
@@ -143,10 +143,12 @@ Examples:
   ez doc file.ez        Generate docs for a single file
   ez doc a.ez b.ez      Generate docs for multiple files
 
-Output is written to DOCS.md in the current working directory.`,
+Output is written to DOCS.md by default. Use -o/--output to write
+to a different path (parent directories are created as needed).`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		generateDocs(args)
+		output, _ := cmd.Flags().GetString("output")
+		generateDocs(args, output)
 	},
 }
 
@@ -505,6 +507,8 @@ Use "ez [command] --help" for more information about a command.
 	rootCmd.Flags().Bool("no-color", false, "Disable colored output")
 	buildCmd.Flags().StringP("quiet", "q", "", "Suppress warnings (use 'all' or comma-separated codes like W1001,W1002)")
 	checkCmd.Flags().StringP("quiet", "q", "", "Suppress warnings (use 'all' or comma-separated codes like W1001,W1002)")
+
+	docCmd.Flags().StringP("output", "o", defaultDocOutputPath, "Path to write generated markdown")
 
 	pzCmd.Flags().StringP("template", "t", "basic", "Template: basic, cli, lib, multi, server, client")
 	pzCmd.Flags().BoolP("comments", "c", false, "Include helpful syntax comments")

--- a/cmd/ez/doc.go
+++ b/cmd/ez/doc.go
@@ -21,8 +21,18 @@ type DocEntry struct {
 	File        string
 }
 
-// generateDocs is the entry point for the ez doc command
-func generateDocs(args []string) {
+// defaultDocOutputPath is used when the caller does not pass --output.
+const defaultDocOutputPath = "DOCS.md"
+
+// generateDocs is the entry point for the ez doc command. outputPath is
+// the destination markdown file; an empty string falls back to
+// defaultDocOutputPath so the legacy `DOCS.md`-in-cwd behavior is
+// unchanged for callers that do not pass --output.
+func generateDocs(args []string, outputPath string) {
+	if outputPath == "" {
+		outputPath = defaultDocOutputPath
+	}
+
 	var entries []DocEntry
 
 	for _, arg := range args {
@@ -46,13 +56,21 @@ func generateDocs(args []string) {
 
 	output := generateMarkdown(entries)
 
-	err := os.WriteFile("DOCS.md", []byte(output), 0644)
-	if err != nil {
-		fmt.Printf("Error writing DOCS.md: %v\n", err)
+	// Make sure the parent directory exists when --output points at a
+	// nested path like docs/API.md.
+	if dir := filepath.Dir(outputPath); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			fmt.Printf("Error creating output directory %s: %v\n", dir, err)
+			return
+		}
+	}
+
+	if err := os.WriteFile(outputPath, []byte(output), 0644); err != nil {
+		fmt.Printf("Error writing %s: %v\n", outputPath, err)
 		return
 	}
 
-	fmt.Printf("Generated DOCS.md with %d documented item(s)\n", len(entries))
+	fmt.Printf("Generated %s with %d documented item(s)\n", outputPath, len(entries))
 }
 
 // collectDocsFromFile extracts documented items from a single .ez file using text scanning.

--- a/cmd/ez/doc_output_test.go
+++ b/cmd/ez/doc_output_test.go
@@ -1,0 +1,99 @@
+package main
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeEZSource writes a tiny .ez source file with one documented
+// function so generateDocs has at least one entry to emit.
+func writeEZSource(t *testing.T, dir string) string {
+	t.Helper()
+	src := `module main
+
+#doc("greet returns a friendly hello.")
+do greet() -> string {
+    return "hello"
+}
+`
+	path := filepath.Join(dir, "main.ez")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+	return path
+}
+
+// runFromTempDir cd's into dir for the duration of fn, then restores
+// the original cwd. generateDocs writes relative paths against cwd, so
+// tests that exercise the default output path need to run inside a
+// scratch directory to avoid polluting the contributor's checkout.
+func runFromTempDir(t *testing.T, dir string, fn func()) {
+	t.Helper()
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir to %s: %v", dir, err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+	fn()
+}
+
+func TestGenerateDocs_DefaultOutputPathUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	src := writeEZSource(t, dir)
+
+	runFromTempDir(t, dir, func() {
+		// Empty outputPath must fall back to DOCS.md in cwd, matching
+		// the pre-flag behavior.
+		generateDocs([]string{src}, "")
+	})
+
+	got, err := os.ReadFile(filepath.Join(dir, "DOCS.md"))
+	if err != nil {
+		t.Fatalf("DOCS.md should be written by default: %v", err)
+	}
+	if !strings.Contains(string(got), "greet") {
+		t.Errorf("DOCS.md missing the documented function, got:\n%s", got)
+	}
+}
+
+func TestGenerateDocs_RespectsCustomOutputPath(t *testing.T) {
+	dir := t.TempDir()
+	src := writeEZSource(t, dir)
+	custom := filepath.Join(dir, "api-reference.md")
+
+	generateDocs([]string{src}, custom)
+
+	got, err := os.ReadFile(custom)
+	if err != nil {
+		t.Fatalf("custom output path %s should be written: %v", custom, err)
+	}
+	if !strings.Contains(string(got), "greet") {
+		t.Errorf("custom output missing the documented function, got:\n%s", got)
+	}
+
+	// And the default DOCS.md must NOT have been written when --output
+	// was specified.
+	if _, err := os.Stat(filepath.Join(dir, "DOCS.md")); !os.IsNotExist(err) {
+		t.Errorf("DOCS.md should not exist when --output points elsewhere; stat err=%v", err)
+	}
+}
+
+func TestGenerateDocs_CreatesParentDirectories(t *testing.T) {
+	dir := t.TempDir()
+	src := writeEZSource(t, dir)
+	nested := filepath.Join(dir, "build", "docs", "API.md")
+
+	generateDocs([]string{src}, nested)
+
+	if _, err := os.Stat(nested); err != nil {
+		t.Fatalf("nested output %s should be created: %v", nested, err)
+	}
+}


### PR DESCRIPTION
Closes #1572.

## Summary
- `ez doc` previously hard-coded its destination to `DOCS.md` in the current working directory, with no way to redirect to a different path.
- Adds `-o` / `--output` (StringP, default `DOCS.md`) to `docCmd` so the default behavior is unchanged for callers that do not pass it.
- `generateDocs` now takes the output path as a parameter and treats `""` as a fall-through to the legacy `DOCS.md` default.
- When the path points at a nested file (e.g. `docs/API.md`), the parent directory is created with `os.MkdirAll` before writing — matches what most tools do for `-o nested/path.ext`.

## Example
```bash
ez doc                       # writes to DOCS.md (unchanged)
ez doc -o api-reference.md   # writes to custom path
ez doc --output docs/API.md  # creates docs/ and writes API.md
```

## Test plan
- [x] `go build ./...` and `go vet ./...` clean
- [x] New `cmd/ez/doc_output_test.go` covers:
  - default path unchanged when `--output` is not passed,
  - `--output` writes to the custom path and `DOCS.md` is **not** created as a side effect,
  - parent directories are created for nested paths.
- [x] Manual smoke: `ez doc -o api/REF.md main.ez` writes the expected file and prints `Generated api/REF.md with 1 documented item(s)`.
- [x] Reverting the fix locally fails to build the new test (signature changed) — confirms the tests exercise the new code path.

## Authorship
Human-authored, following the implementation guidance in #1572. AI tooling was used to draft and review per the project's AI-assisted contribution policy; the code was built, tested, and verified locally before pushing.