### PR TITLE
chore: add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,46 @@
+# EditorConfig is awesome: https://editorconfig.org
+#
+# Editor-agnostic defaults for the EZ repo. Captures the conventions
+# that already live in the source: 4-space indent for C, gofmt-style
+# tabs for Go, tabs for Makefiles, 2-space indent for YAML/Markdown,
+# UTF-8 encoding, and LF line endings.
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+# Go: gofmt enforces tabs.
+[*.go]
+indent_style = tab
+
+# C/C++: 4-space indent matches `ezc/.clang-format` (IndentWidth: 4).
+[*.{c,h,cpp,hpp}]
+indent_style = space
+indent_size = 4
+
+# Makefiles require literal tabs in recipe lines.
+[{Makefile,makefile,GNUmakefile,*.mk}]
+indent_style = tab
+
+# YAML/JSON/TOML: 2-space indent matches the workflow files.
+[*.{yml,yaml,json,toml}]
+indent_style = space
+indent_size = 2
+
+# Markdown allows trailing spaces (for hard line breaks); keep
+# everything else consistent with the global section.
+[*.md]
+trim_trailing_whitespace = false
+indent_style = space
+indent_size = 2
+
+# Shell scripts: 2-space indent, LF, final newline.
+[*.{sh,bash,zsh}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Closes #1571.

## Summary
Adds a root `.editorconfig` that captures the formatting conventions already present in the repo, so contributors using any EditorConfig-aware editor (VS Code, Vim, Emacs, JetBrains, etc.) get the right defaults automatically.

| File group              | Setting                            | Source of truth          |
|-------------------------|-------------------------------------|---------------------------|
| C / C++ (`*.c`, `*.h`)  | 4-space indent                     | `ezc/.clang-format`       |
| Go (`*.go`)             | tab indent                         | gofmt                     |
| Makefiles               | tab indent                         | required by `make`        |
| YAML/JSON/TOML          | 2-space indent                     | existing workflow files   |
| Shell scripts           | 2-space indent                     | community convention      |
| Markdown                | trailing whitespace preserved      | hard line breaks need it  |
| Everything              | UTF-8, LF, final newline           | global defaults           |

## What this does *not* do
- No source files are reformatted in this change. The `.editorconfig` only affects *new* edits going forward.
- No CI step is added.

## Test plan
- [x] No code changes, so `make build` / `make test` are unchanged.
- [x] Spot-checked the file by opening it in an editor with the EditorConfig plugin — switching between a `.c` file and a `.go` file produces the documented indent style.