### PR TITLE
chore(ci): inject version ldflags in release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -154,7 +154,10 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
-        run: go build -o ez ./cmd/ez
+        run: |
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          BUILD_TIME=$(date -u '+%Y-%m-%d_%H:%M:%S')
+          go build -ldflags "-X main.Version=${TAG} -X main.BuildTime=${BUILD_TIME}" -o ez ./cmd/ez
         shell: bash
 
       - name: Package single-binary release


### PR DESCRIPTION
## Summary

- Release binaries were built with bare `go build -o ez ./cmd/ez`, missing the `-ldflags` that inject `Version` and `BuildTime`
- This caused every released binary to report `dev (dev build)` and `Built: unknown` when users ran `ez version` after installing via `ez install`
- Now passes `-X main.Version=${TAG} -X main.BuildTime=${BUILD_TIME}` matching what the Makefile does for local builds