### PR TITLE
feat: pass --quiet and --no-color flags through ez watch

### DIFF
--- a/cmd/ez/commands.go
+++ b/cmd/ez/commands.go
@@ -507,6 +507,8 @@ Use "ez [command] --help" for more information about a command.
 	rootCmd.Flags().Bool("no-color", false, "Disable colored output")
 	buildCmd.Flags().StringP("quiet", "q", "", "Suppress warnings (use 'all' or comma-separated codes like W1001,W1002)")
 	checkCmd.Flags().StringP("quiet", "q", "", "Suppress warnings (use 'all' or comma-separated codes like W1001,W1002)")
+	watchCmd.Flags().StringP("quiet", "q", "", "Suppress warnings (use 'all' or comma-separated codes like W1001,W1002)")
+	watchCmd.Flags().Bool("no-color", false, "Disable colored output")
 
 	docCmd.Flags().StringP("output", "o", defaultDocOutputPath, "Path to write generated markdown")
 

--- a/cmd/ez/watch.go
+++ b/cmd/ez/watch.go
@@ -25,6 +25,17 @@ var watchCmd = &cobra.Command{
 func runWatch(cmd *cobra.Command, args []string) {
 	target := args[0]
 
+	var compilerArgs []string
+	quiet, _ := cmd.Flags().GetString("quiet")
+	if quiet == "all" {
+		compilerArgs = append(compilerArgs, "--quiet")
+	} else if quiet != "" {
+		compilerArgs = append(compilerArgs, "--quiet", quiet)
+	}
+	if noColor, _ := cmd.Flags().GetBool("no-color"); noColor {
+		compilerArgs = append(compilerArgs, "--no-color")
+	}
+
 	// Resolve to absolute path
 	absTarget, err := filepath.Abs(target)
 	if err != nil {
@@ -40,18 +51,18 @@ func runWatch(cmd *cobra.Command, args []string) {
 	}
 
 	if info.IsDir() {
-		watchDirectory(absTarget)
+		watchDirectory(absTarget, compilerArgs)
 	} else {
 		if !strings.HasSuffix(absTarget, ".ez") {
 			fmt.Println("Error: file must have .ez extension")
 			os.Exit(1)
 		}
-		watchFile(absTarget)
+		watchFile(absTarget, compilerArgs)
 	}
 }
 
 // watchFile watches a single file and its imports for changes
-func watchFile(file string) {
+func watchFile(file string, compilerArgs []string) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		fmt.Printf("Error creating watcher: %v\n", err)
@@ -78,7 +89,7 @@ func watchFile(file string) {
 	fmt.Println()
 
 	// Run initially
-	executeFile(file)
+	executeFile(file, compilerArgs)
 
 	var mu sync.Mutex
 	var timer *time.Timer
@@ -100,7 +111,7 @@ func watchFile(file string) {
 					for _, f := range newFilesToWatch {
 						watcher.Add(f)
 					}
-					executeFile(file)
+					executeFile(file, compilerArgs)
 				})
 				mu.Unlock()
 			}
@@ -114,7 +125,7 @@ func watchFile(file string) {
 }
 
 // watchDirectory watches all .ez files in a directory
-func watchDirectory(dirPath string) {
+func watchDirectory(dirPath string, compilerArgs []string) {
 	mainFile, err := findMainFile(dirPath)
 	if err != nil {
 		fmt.Println(err)
@@ -140,7 +151,7 @@ func watchDirectory(dirPath string) {
 	fmt.Println("Press Ctrl+C to stop")
 	fmt.Println()
 
-	executeFile(mainFile)
+	executeFile(mainFile, compilerArgs)
 
 	var mu sync.Mutex
 	var timer *time.Timer
@@ -165,7 +176,7 @@ func watchDirectory(dirPath string) {
 					for _, f := range newFilesToWatch {
 						watcher.Add(f)
 					}
-					executeFile(mainFile)
+					executeFile(mainFile, compilerArgs)
 				})
 				mu.Unlock()
 			}
@@ -310,11 +321,11 @@ func hasMainFunction(filePath string) bool {
 }
 
 // executeFile runs the given file via ezc and prints output
-func executeFile(filename string) {
+func executeFile(filename string, compilerArgs []string) {
 	timestamp := time.Now().Format("15:04:05")
 	fmt.Printf("[%s] Running %s...\n", timestamp, shortPath(filename))
 
-	_, err := ezc.Run(filename, nil)
+	_, err := ezc.Run(filename, compilerArgs)
 	if err != nil {
 		fmt.Printf("Error: %v\n", err)
 	}


### PR DESCRIPTION
## Summary

`ez watch` re-runs the compiler on file changes but didn't accept `--quiet` or `--no-color`, unlike `ez build` and `ez check`. This PR adds both flags to `watchCmd` and passes them through to each `ezc.Run` invocation, mirroring the existing pattern in `buildCmd`.

## What changed

- `cmd/ez/commands.go` — register `--quiet`/`-q` (string) and `--no-color` (bool) on `watchCmd` (mirror of the existing `buildCmd`/`checkCmd` registrations a few lines above).
- `cmd/ez/watch.go` — in `runWatch`, build a `compilerArgs []string` from `cmd.Flags()` using the same `if quiet == "all"` / `else if quiet != ""` / `noColor` shape as `buildCmd` (commands.go:440-450). Plumb the slice through `watchFile`, `watchDirectory`, and `executeFile` so each rerun calls `ezc.Run(filename, compilerArgs)` instead of `ezc.Run(filename, nil)`.

23 lines added, 10 removed across two files.

## Verification

- `go build ./...` and `go vet ./...` pass.
- `make test` — 907/907 passing.
- Manual smoke with a stub `ezc` confirms the slice reaches the compiler:
  - `ez watch foo.ez --no-color` → `run foo.ez --no-color`
  - `ez watch foo.ez -q W1001` → `run foo.ez --quiet W1001`
  - `ez watch foo.ez -q all` → `run foo.ez --quiet`
  - `ez watch foo.ez` → `run foo.ez` (nil args, unchanged behavior)

Closes #1573

This contribution was developed with AI assistance.