### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: Bug Report
+description: Report a bug in the EZ compiler, runtime, stdlib, or tooling
+title: "bug: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The fields below mirror the
+        bug-report template in [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#bug-reports)
+        — fill them out and a maintainer will triage quickly.
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: How serious is this bug?
+      options:
+        - Crash (compiler or runtime aborts)
+        - Incorrect output (program runs but produces the wrong result)
+        - Misleading error (compile-time error message is confusing or wrong)
+        - Cosmetic (formatting / wording / minor UX)
+    validations:
+      required: true
+
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System info — paste the full output of `ez report`
+      description: |
+        Run `ez report` and paste the complete output. Version, commit, install
+        path, OS, CPU, RAM, and C compiler info are all load-bearing for triage.
+      placeholder: |
+        $ ez report
+        ...
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One paragraph. What's broken, in plain language.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Minimal `.ez` program that triggers the bug. Inline the code below.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: |
+        What actually happens. Include the error message verbatim if there is
+        one.
+    validations:
+      required: true
+
+  - type: textarea
+    id: where-to-look
+    attributes:
+      label: Where to look (optional)
+      description: |
+        If you have a guess at the root cause, note it here. Saves triage time.
+
+  - type: textarea
+    id: related
+    attributes:
+      label: Related (optional)
+      description: Link any related issues or recent commits that touched the same area.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: EZ Language Specification
+    url: https://github.com/SchoolyB/EZ/blob/main/STANDARD.md
+    about: Before filing a syntax / semantics issue, skim STANDARD.md — the canonical reference.
+  - name: Contributing Guide
+    url: https://github.com/SchoolyB/EZ/blob/main/CONTRIBUTING.md
+    about: Building from source, running tests, code style, and how to submit a PR.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for EZ
+title: "feat: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest an enhancement. The fields below
+        mirror the feature-request template in
+        [CONTRIBUTING.md](../blob/main/CONTRIBUTING.md#feature-requests).
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What should the feature do? Plain language is fine.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: |
+        Why is this needed? What problem does it solve, or what does it unlock,
+        that the current language or tooling doesn't?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: |
+        Other approaches you weighed and why they fall short. Helps the
+        discussion converge faster.
+    validations:
+      required: true
+
+  - type: textarea
+    id: examples
+    attributes:
+      label: Examples (optional)
+      description: |
+        Sketch how the feature would look in EZ source. Pseudo-syntax is fine.
+      render: text


### PR DESCRIPTION
Closes #1569.

The repo had no `.github/ISSUE_TEMPLATE/` directory, so anyone filing an issue hit an empty form and the bug-report template documented in `CONTRIBUTING.md` (the `## Reporting Issues` / `### Bug Reports` section) had no automatic enforcement at filing time.

This adds three YAML issue forms under `.github/ISSUE_TEMPLATE/`:

- **`bug_report.yml`** — title prefix `bug: `, severity dropdown matching the CONTRIBUTING table (Crash / Incorrect output / Misleading error / Cosmetic), required `ez report` system-info paste, summary, reproduction (`.ez` snippet), expected, actual, plus optional `Where to look` and `Related` sections. Mirrors the markdown template in `CONTRIBUTING.md` so the form output reads cleanly when triaged.
- **`feature_request.yml`** — title prefix `feat: `, required Description / Use case / Alternatives considered, plus an optional Examples section.
- **`config.yml`** — `blank_issues_enabled: false` plus contact links pointing readers at `STANDARD.md` (language spec, the canonical reference) and `CONTRIBUTING.md` (build / test / code style / PR process) as the first stop before filing.

All three files pass `yaml.safe_load`.