### PR TITLE
chore: compiler memory safety, perf, and CodeQL cleanup

### DIFF
--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -1698,13 +1698,16 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
                 size_t mem_len = strlen(mem);
                 size_t cn_len = mod_len + 1 + mem_len + 1;
                 char *check_name = malloc(cn_len);
+                if (!check_name) break;
                 snprintf(check_name, cn_len, "%s_%s", mod, mem);
                 /* Check functions, variables via find_func */
                 if (find_func(cg, check_name)) is_module = true;
+                free(check_name);
                 /* Check if any function starts with mod_ prefix */
                 if (!is_module) {
                     size_t pfx_len = mod_len + 2;
                     char *prefix = malloc(pfx_len);
+                    if (!prefix) break;
                     snprintf(prefix, pfx_len, "%s_", mod);
                     size_t plen = pfx_len - 1;
                     for (int fi = 0; fi < cg->func_count; fi++) {
@@ -1713,6 +1716,7 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
                             break;
                         }
                     }
+                    free(prefix);
                 }
                 /* Check using_modules list */
                 if (!is_module) {

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -8,6 +8,7 @@
 
 #include "codegen.h"
 #include "../util/constants.h"
+#include "../util/xalloc.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -68,7 +69,7 @@ static void emitf(CodeGen *cg, const char *fmt, ...) {
     if (req > cg->output.cap) {
         size_t new_cap = cg->output.cap * 2;
         if (new_cap < req) new_cap = req;
-        cg->output.data = realloc(cg->output.data, new_cap);
+        cg->output.data = xrealloc(cg->output.data, new_cap);
         cg->output.cap = new_cap;
     }
 
@@ -518,7 +519,7 @@ static bool is_ref_var(CodeGen *cg, const char *name) {
 static void register_ref_var(CodeGen *cg, const char *name) {
     if (cg->ref_var_count >= cg->ref_var_cap) {
         cg->ref_var_cap = cg->ref_var_cap ? cg->ref_var_cap * 2 : 8;
-        cg->ref_vars = realloc(cg->ref_vars, sizeof(const char *) * cg->ref_var_cap);
+        cg->ref_vars = xrealloc(cg->ref_vars, sizeof(const char *) * cg->ref_var_cap);
     }
     cg->ref_vars[cg->ref_var_count++] = name;
 }
@@ -534,8 +535,8 @@ static bool is_bigint_type(const char *tn) {
 static void register_bigint_var(CodeGen *cg, const char *name, const char *type_name) {
     if (cg->bigint_var_count >= cg->bigint_var_cap) {
         cg->bigint_var_cap = cg->bigint_var_cap ? cg->bigint_var_cap * 2 : 8;
-        cg->bigint_var_names = realloc(cg->bigint_var_names, sizeof(const char *) * cg->bigint_var_cap);
-        cg->bigint_var_types = realloc(cg->bigint_var_types, sizeof(const char *) * cg->bigint_var_cap);
+        cg->bigint_var_names = xrealloc(cg->bigint_var_names, sizeof(const char *) * cg->bigint_var_cap);
+        cg->bigint_var_types = xrealloc(cg->bigint_var_types, sizeof(const char *) * cg->bigint_var_cap);
     }
     cg->bigint_var_names[cg->bigint_var_count] = name;
     cg->bigint_var_types[cg->bigint_var_count] = type_name;
@@ -7171,7 +7172,7 @@ static void emit_statement(CodeGen *cg, AstNode *node) {
         for (int j = 0; j < node->data.using_stmt.count; j++) {
             if (cg->using_module_count >= cg->using_module_cap) {
                 cg->using_module_cap = cg->using_module_cap ? cg->using_module_cap * 2 : 8;
-                cg->using_modules = realloc(cg->using_modules,
+                cg->using_modules = xrealloc(cg->using_modules,
                     sizeof(const char *) * (size_t)cg->using_module_cap);
             }
             cg->using_modules[cg->using_module_count++] = node->data.using_stmt.modules[j];
@@ -7258,7 +7259,7 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
                     cg->has_c_imports = true;
                     if (cg->c_header_count >= cg->c_header_cap) {
                         cg->c_header_cap = cg->c_header_cap ? cg->c_header_cap * 2 : 4;
-                        cg->c_headers = realloc(cg->c_headers,
+                        cg->c_headers = xrealloc(cg->c_headers,
                             sizeof(const char *) * (size_t)cg->c_header_cap);
                     }
                     cg->c_headers[cg->c_header_count++] = item->path;
@@ -7268,7 +7269,7 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
                     const char *mname = item->alias ? item->alias : item->module;
                     if (cg->imported_module_count >= cg->imported_module_cap) {
                         cg->imported_module_cap = cg->imported_module_cap ? cg->imported_module_cap * 2 : 8;
-                        cg->imported_modules = realloc(cg->imported_modules,
+                        cg->imported_modules = xrealloc(cg->imported_modules,
                             sizeof(const char *) * (size_t)cg->imported_module_cap);
                     }
                     cg->imported_modules[cg->imported_module_count++] = mname;
@@ -7277,9 +7278,9 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
                 if (item->alias && item->module && strcmp(item->alias, item->module) != 0) {
                     if (cg->alias_count >= cg->alias_cap) {
                         cg->alias_cap = cg->alias_cap ? cg->alias_cap * 2 : 8;
-                        cg->alias_names = realloc(cg->alias_names,
+                        cg->alias_names = xrealloc(cg->alias_names,
                             sizeof(const char *) * (size_t)cg->alias_cap);
-                        cg->alias_modules = realloc(cg->alias_modules,
+                        cg->alias_modules = xrealloc(cg->alias_modules,
                             sizeof(const char *) * (size_t)cg->alias_cap);
                     }
                     cg->alias_names[cg->alias_count] = item->alias;
@@ -7294,7 +7295,7 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
                     if (item->module) {
                         if (cg->using_module_count >= cg->using_module_cap) {
                             cg->using_module_cap = cg->using_module_cap ? cg->using_module_cap * 2 : 8;
-                            cg->using_modules = realloc(cg->using_modules,
+                            cg->using_modules = xrealloc(cg->using_modules,
                                 sizeof(const char *) * (size_t)cg->using_module_cap);
                         }
                         cg->using_modules[cg->using_module_count++] = item->module;
@@ -7306,7 +7307,7 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
             for (int j = 0; j < stmt->data.using_stmt.count; j++) {
                 if (cg->using_module_count >= cg->using_module_cap) {
                     cg->using_module_cap = cg->using_module_cap ? cg->using_module_cap * 2 : 8;
-                    cg->using_modules = realloc(cg->using_modules,
+                    cg->using_modules = xrealloc(cg->using_modules,
                         sizeof(const char *) * (size_t)cg->using_module_cap);
                 }
                 cg->using_modules[cg->using_module_count++] = stmt->data.using_stmt.modules[j];
@@ -7315,7 +7316,7 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
         if (stmt->kind == NODE_STRUCT_DECL) {
             if (cg->struct_decl_count >= cg->struct_decl_cap) {
                 cg->struct_decl_cap = cg->struct_decl_cap ? cg->struct_decl_cap * 2 : 16;
-                cg->struct_decls = realloc(cg->struct_decls,
+                cg->struct_decls = xrealloc(cg->struct_decls,
                     sizeof(AstNode *) * (size_t)cg->struct_decl_cap);
             }
             cg->struct_decls[cg->struct_decl_count++] = stmt;
@@ -7382,7 +7383,7 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
             /* Register enum name */
             if (cg->enum_count >= cg->enum_cap) {
                 cg->enum_cap = cg->enum_cap ? cg->enum_cap * 2 : 8;
-                cg->enum_names = realloc(cg->enum_names, sizeof(const char *) * cg->enum_cap);
+                cg->enum_names = xrealloc(cg->enum_names, sizeof(const char *) * cg->enum_cap);
             }
             cg->enum_names[cg->enum_count++] = stmt->data.enum_decl.name;
 
@@ -7655,7 +7656,7 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
         if (stmt->kind == NODE_FUNC_DECL) {
             if (cg->func_count >= cg->func_cap) {
                 cg->func_cap = cg->func_cap ? cg->func_cap * 2 : 16;
-                cg->all_funcs = realloc(cg->all_funcs, sizeof(AstNode *) * cg->func_cap);
+                cg->all_funcs = xrealloc(cg->all_funcs, sizeof(AstNode *) * cg->func_cap);
             }
             cg->all_funcs[cg->func_count++] = stmt;
         }
@@ -7675,7 +7676,7 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
 
                     if (cg->func_count >= cg->func_cap) {
                         cg->func_cap = cg->func_cap ? cg->func_cap * 2 : 16;
-                        cg->all_funcs = realloc(cg->all_funcs, sizeof(AstNode *) * cg->func_cap);
+                        cg->all_funcs = xrealloc(cg->all_funcs, sizeof(AstNode *) * cg->func_cap);
                     }
                     cg->all_funcs[cg->func_count++] = fn;
                 }

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -5206,8 +5206,10 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
                             const char *rn_b = fref->data.member.member;
                             size_t rn_len = strlen(rn_a) + 1 + strlen(rn_b) + 1;
                             char *rn = malloc(rn_len);
+                            if (!rn) continue;
                             snprintf(rn, rn_len, "%s_%s", rn_a, rn_b);
                             ref_func = find_func(cg, rn);
+                            free(rn);
                         }
                     }
                 }

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -589,14 +589,32 @@ static bool is_mutable_param(CodeGen *cg, const char *name) {
     return false;
 }
 
-/* Find a function declaration by name */
+static int func_name_cmp(const void *a, const void *b) {
+    const AstNode *fa = *(const AstNode *const *)a;
+    const AstNode *fb = *(const AstNode *const *)b;
+    return strcmp(fa->data.func_decl.name, fb->data.func_decl.name);
+}
+
+/* Find a function declaration by name. Builds and reuses a sorted view of
+ * cg->all_funcs so lookups are O(log n) after the first call. The view is
+ * invalidated whenever a new function is registered (see register sites). */
 static AstNode *find_func(CodeGen *cg, const char *name) {
-    for (int i = 0; i < cg->func_count; i++) {
-        if (strcmp(cg->all_funcs[i]->data.func_decl.name, name) == 0) {
-            return cg->all_funcs[i];
-        }
+    if (cg->func_count == 0) return NULL;
+    if (!cg->funcs_by_name_built) {
+        cg->funcs_by_name = xrealloc(cg->funcs_by_name,
+            sizeof(AstNode *) * (size_t)cg->func_count);
+        memcpy(cg->funcs_by_name, cg->all_funcs,
+            sizeof(AstNode *) * (size_t)cg->func_count);
+        qsort(cg->funcs_by_name, (size_t)cg->func_count, sizeof(AstNode *), func_name_cmp);
+        cg->funcs_by_name_built = true;
     }
-    return NULL;
+    /* Build a stack key node so bsearch can compare against the name field. */
+    AstNode key;
+    key.data.func_decl.name = name;
+    AstNode *key_ptr = &key;
+    AstNode **hit = bsearch(&key_ptr, cg->funcs_by_name, (size_t)cg->func_count,
+        sizeof(AstNode *), func_name_cmp);
+    return hit ? *hit : NULL;
 }
 
 /* Build the (field_name, struct_name) index for func-typed fields once.
@@ -7233,6 +7251,8 @@ CodeGen codegen_create(const char *file) {
     cg.all_funcs = NULL;
     cg.func_count = 0;
     cg.func_cap = 0;
+    cg.funcs_by_name = NULL;
+    cg.funcs_by_name_built = false;
     cg.type_table = NULL;
     cg.ref_vars = NULL;
     cg.ref_var_count = 0;
@@ -7857,6 +7877,7 @@ void codegen_destroy(CodeGen *cg) {
     buf_destroy(&cg->output);
     free(cg->enum_names);
     free(cg->all_funcs);
+    free(cg->funcs_by_name);
     free(cg->ref_vars);
     free(cg->bigint_var_names);
     free(cg->bigint_var_types);

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -4948,8 +4948,10 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
             /* Try to find as a namespaced function: Name_func or ResolvedAlias_func */
             size_t ns_len = strlen(resolved_name) + 1 + strlen(member) + 1;
             char *ns_name = malloc(ns_len);
+            if (!ns_name) return;
             snprintf(ns_name, ns_len, "%s_%s", resolved_name, member);
             AstNode *ns_func = find_func(cg, ns_name);
+            free(ns_name);
             if (!ns_func) {
                 /* : check if `member` is a func-typed data field
                  * on the struct. If so, emit as a function-pointer call

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -599,6 +599,33 @@ static AstNode *find_func(CodeGen *cg, const char *name) {
     return NULL;
 }
 
+/* Build the (field_name, struct_name) index for func-typed fields once.
+ * Order matches struct_decls so the first-match heuristic is preserved. */
+static void build_func_field_index(CodeGen *cg) {
+    if (cg->func_field_index_built) return;
+    int total = 0;
+    for (int si = 0; si < cg->struct_decl_count; si++) {
+        total += cg->struct_decls[si]->data.struct_decl.field_count;
+    }
+    if (total > 0) {
+        cg->func_field_index = xmalloc(sizeof(*cg->func_field_index) * (size_t)total);
+    }
+    for (int si = 0; si < cg->struct_decl_count; si++) {
+        AstNode *sd = cg->struct_decls[si];
+        for (int fi = 0; fi < sd->data.struct_decl.field_count; fi++) {
+            StructField *sf = &sd->data.struct_decl.fields[fi];
+            if (sf->type_name &&
+                (strcmp(sf->type_name, "func") == 0 ||
+                 strncmp(sf->type_name, "func(", 5) == 0)) {
+                cg->func_field_index[cg->func_field_count].field_name = sf->name;
+                cg->func_field_index[cg->func_field_count].struct_name = sd->data.struct_decl.name;
+                cg->func_field_count++;
+            }
+        }
+    }
+    cg->func_field_index_built = true;
+}
+
 /* --- Expression Emission --- */
 
 static void emit_expression(CodeGen *cg, AstNode *node) {
@@ -4967,17 +4994,12 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
                 /* Fall back to scanning struct decls if the type_table
                  * doesn't have a hit for the label. */
                 if (!inst_t || inst_t->kind == TK_UNKNOWN) {
-                    for (int si = 0; si < cg->struct_decl_count; si++) {
-                        const char *sn = cg->struct_decls[si]->data.struct_decl.name;
-                        for (int fi = 0; fi < cg->struct_decls[si]->data.struct_decl.field_count; fi++) {
-                            StructField *sf = &cg->struct_decls[si]->data.struct_decl.fields[fi];
-                            if (strcmp(sf->name, member) == 0 && sf->type_name &&
-                                (strcmp(sf->type_name, "func") == 0 || strncmp(sf->type_name, "func(", 5) == 0)) {
-                                inst_t = type_struct(sn);
-                                break;
-                            }
+                    build_func_field_index(cg);
+                    for (int i = 0; i < cg->func_field_count; i++) {
+                        if (strcmp(cg->func_field_index[i].field_name, member) == 0) {
+                            inst_t = type_struct(cg->func_field_index[i].struct_name);
+                            break;
                         }
-                        if (inst_t && inst_t->kind == TK_STRUCT) break;
                     }
                 }
                 if (inst_t && (inst_t->kind == TK_STRUCT || inst_t->kind == TK_POINTER)) {
@@ -7222,6 +7244,9 @@ CodeGen codegen_create(const char *file) {
     cg.struct_decls = NULL;
     cg.struct_decl_count = 0;
     cg.struct_decl_cap = 0;
+    cg.func_field_index = NULL;
+    cg.func_field_count = 0;
+    cg.func_field_index_built = false;
     cg.using_modules = NULL;
     cg.using_module_count = 0;
     cg.using_module_cap = 0;
@@ -7836,6 +7861,7 @@ void codegen_destroy(CodeGen *cg) {
     free(cg->bigint_var_names);
     free(cg->bigint_var_types);
     free(cg->struct_decls);
+    free(cg->func_field_index);
     free(cg->using_modules);
     free(cg->alias_names);
     free(cg->alias_modules);

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -2337,7 +2337,7 @@ static void emit_value_print(CodeGen *cg, const char *c_expr, EzType *t, const c
         if (in_container) {
             emitf(cg, "{ EzString _cs = ez_builtin_char_to_utf8(ez_default_arena, %s); fprintf(%s, \"'\"); fwrite(_cs.data, 1, (size_t)_cs.len, %s); fprintf(%s, \"'\"); }\n", c_expr, stream, stream, stream);
         } else {
-            emitf(cg, "{ EzString _cs = ez_builtin_char_to_utf8(ez_default_arena, %s); fwrite(_cs.data, 1, (size_t)_cs.len, %s); }\n", c_expr, stream, stream);
+            emitf(cg, "{ EzString _cs = ez_builtin_char_to_utf8(ez_default_arena, %s); fwrite(_cs.data, 1, (size_t)_cs.len, %s); }\n", c_expr, stream);
         }
         break;
     case TK_NIL:

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -7774,12 +7774,16 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
         const char *orig_name = stmt->data.func_decl.name;
         for (int r = 0; r < emit_rounds; r++) {
             const char *saved_binding = cg->wildcard_binding;
-            char mangled[EZ_MSG_BUF_SIZE];
+            /* mangled is heap-allocated so the AST temporarily points at
+             * stable memory while emit_multi_return_typedef / func_return_type
+             * read stmt->data.func_decl.name. */
+            char *mangled = NULL;
             if (has_wc) {
+                mangled = xmalloc(EZ_MSG_BUF_SIZE);
                 const char *concrete = stmt->data.func_decl.instantiations[r];
                 cg->wildcard_binding = concrete;
-                size_t pos = snprintf(mangled, sizeof(mangled), "%s__", orig_name);
-                for (const char *c = concrete; *c && pos < sizeof(mangled) - 1; c++) {
+                size_t pos = snprintf(mangled, EZ_MSG_BUF_SIZE, "%s__", orig_name);
+                for (const char *c = concrete; *c && pos < EZ_MSG_BUF_SIZE - 1; c++) {
                     mangled[pos++] = (isalnum((unsigned char)*c) || *c == '_') ? *c : '_';
                 }
                 mangled[pos] = '\0';
@@ -7819,6 +7823,7 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
             }
             emit(cg, ");\n");
             cg->wildcard_binding = saved_binding;
+            free(mangled);
         }
     }
     emit(cg, "\n");

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -5155,6 +5155,7 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
             size_t bind_len = binding ? strlen(binding) : 0;
             size_t mn_need = 6 + rfn_len + 2 + bind_len + 1; /* 6 = strlen("ez_fn_") */
             char *mangled = malloc(mn_need);
+            if (!mangled) return;
             size_t pos = (size_t)snprintf(mangled, mn_need, "ez_fn_%s__",
                 resolved_fn_name);
             if (binding) {
@@ -5164,6 +5165,7 @@ static void emit_call_expression(CodeGen *cg, AstNode *node) {
             }
             mangled[pos] = '\0';
             emit(cg, mangled);
+            free(mangled);
         } else {
             emit(cg, "ez_fn_");
             emit(cg, resolved_fn_name);

--- a/ezc/src/codegen/codegen.h
+++ b/ezc/src/codegen/codegen.h
@@ -36,6 +36,12 @@ typedef struct {
     int func_count;
     int func_cap;
 
+    /* Sorted view of all_funcs by func_decl.name, built lazily for
+     * O(log n) find_func lookups. all_funcs itself stays in insertion
+     * order because emission and several prefix-match scans depend on it. */
+    AstNode **funcs_by_name;
+    bool funcs_by_name_built;
+
     /* Type table from type checker (for type-aware codegen) */
     TypeTable *type_table;
 

--- a/ezc/src/codegen/codegen.h
+++ b/ezc/src/codegen/codegen.h
@@ -59,6 +59,16 @@ typedef struct {
     int struct_decl_count;
     int struct_decl_cap;
 
+    /* Lazy index of (field_name, struct_name) for func-typed struct fields,
+     * built on first lookup. Lets the member-call fallback heuristic skip
+     * the O(struct_count * field_count) scan over non-func fields. */
+    struct {
+        const char *field_name;
+        const char *struct_name;
+    } *func_field_index;
+    int func_field_count;
+    bool func_field_index_built;
+
     /* Modules brought into scope via 'using' or 'import and use' */
     const char **using_modules;
     int using_module_count;

--- a/ezc/src/stdlib/ez_io.c
+++ b/ezc/src/stdlib/ez_io.c
@@ -6,6 +6,7 @@
  */
 
 #include "ez_io.h"
+#include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
@@ -18,6 +19,7 @@
 #define EZ_IO_COPY_BUF          8192
 #define EZ_IO_MAX_SEGMENTS      256
 #define EZ_IO_DIR_MODE          0755
+#define EZ_IO_FILE_MODE         0644
 #define EZ_IO_WALK_INITIAL_CAP  32
 
 /* ---- Path manipulation (pure, no I/O) ---- */
@@ -223,8 +225,10 @@ bool ez_io_rename_file(EzString old_path, EzString new_path) {
 bool ez_io_copy_file(EzString src, EzString dst) {
     FILE *in = fopen(src.data, "rb");
     if (!in) return false;
-    FILE *out = fopen(dst.data, "wb");
-    if (!out) { fclose(in); return false; }
+    int out_fd = open(dst.data, O_WRONLY | O_CREAT | O_TRUNC, EZ_IO_FILE_MODE);
+    if (out_fd < 0) { fclose(in); return false; }
+    FILE *out = fdopen(out_fd, "wb");
+    if (!out) { close(out_fd); fclose(in); return false; }
     char buf[EZ_IO_COPY_BUF];
     size_t n;
     bool ok = true;

--- a/ezc/src/stdlib/ez_strconv.c
+++ b/ezc/src/stdlib/ez_strconv.c
@@ -9,6 +9,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <strings.h>
 
 #define STRCONV_BUF_SIZE 64
 
@@ -82,19 +83,10 @@ double ez_strconv_to_float(EzString s) {
 }
 
 bool ez_strconv_to_bool(EzString s) {
-    if (s.len == 4 &&
-        (s.data[0] == 't' || s.data[0] == 'T') &&
-        (s.data[1] == 'r' || s.data[1] == 'R') &&
-        (s.data[2] == 'u' || s.data[2] == 'U') &&
-        (s.data[3] == 'e' || s.data[3] == 'E')) {
+    if (s.len == 4 && strncasecmp(s.data, "true", 4) == 0) {
         return true;
     }
-    if (s.len == 5 &&
-        (s.data[0] == 'f' || s.data[0] == 'F') &&
-        (s.data[1] == 'a' || s.data[1] == 'A') &&
-        (s.data[2] == 'l' || s.data[2] == 'L') &&
-        (s.data[3] == 's' || s.data[3] == 'S') &&
-        (s.data[4] == 'e' || s.data[4] == 'E')) {
+    if (s.len == 5 && strncasecmp(s.data, "false", 5) == 0) {
         return false;
     }
     fflush(stdout);
@@ -176,19 +168,10 @@ EzResult_float ez_strconv_to_float_result(EzString s) {
 }
 
 EzResult_bool ez_strconv_to_bool_result(EzString s) {
-    if (s.len == 4 &&
-        (s.data[0] == 't' || s.data[0] == 'T') &&
-        (s.data[1] == 'r' || s.data[1] == 'R') &&
-        (s.data[2] == 'u' || s.data[2] == 'U') &&
-        (s.data[3] == 'e' || s.data[3] == 'E')) {
+    if (s.len == 4 && strncasecmp(s.data, "true", 4) == 0) {
         return (EzResult_bool){true, NULL};
     }
-    if (s.len == 5 &&
-        (s.data[0] == 'f' || s.data[0] == 'F') &&
-        (s.data[1] == 'a' || s.data[1] == 'A') &&
-        (s.data[2] == 'l' || s.data[2] == 'L') &&
-        (s.data[3] == 's' || s.data[3] == 'S') &&
-        (s.data[4] == 'e' || s.data[4] == 'E')) {
+    if (s.len == 5 && strncasecmp(s.data, "false", 5) == 0) {
         return (EzResult_bool){false, NULL};
     }
     EzString msg = ez_string_lit("cannot convert string to bool");

--- a/ezc/src/typechecker/scope.c
+++ b/ezc/src/typechecker/scope.c
@@ -6,13 +6,15 @@
  */
 
 #include "scope.h"
+#include "../util/xalloc.h"
 #include <stdlib.h>
 #include <string.h>
 
 #define EZ_SCOPE_INITIAL_CAP 8
 
 Scope *scope_create(Scope *parent) {
-    Scope *s = calloc(1, sizeof(Scope));
+    Scope *s = xmalloc(sizeof(Scope));
+    memset(s, 0, sizeof(Scope));
     s->parent = parent;
     return s;
 }
@@ -28,7 +30,7 @@ void scope_define(Scope *s, const char *name, EzType *type, bool mutable) {
 
     if (s->count >= s->cap) {
         s->cap = s->cap ? s->cap * 2 : EZ_SCOPE_INITIAL_CAP;
-        s->symbols = realloc(s->symbols, sizeof(Symbol) * s->cap);
+        s->symbols = xrealloc(s->symbols, sizeof(Symbol) * s->cap);
     }
 
     Symbol *sym = &s->symbols[s->count++];

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -9,6 +9,7 @@
 
 #include "typechecker.h"
 #include "../util/constants.h"
+#include "../util/xalloc.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,10 +40,10 @@ static uint32_t hash_ptr(const void *ptr) {
 }
 
 TypeTable *typetable_create(void) {
-    TypeTable *tt = calloc(1, sizeof(TypeTable));
+    TypeTable *tt = xcalloc(1, sizeof(TypeTable));
     tt->cap = TYPETABLE_INIT_CAP;
-    tt->nodes = calloc((size_t)tt->cap, sizeof(AstNode *));
-    tt->types = calloc((size_t)tt->cap, sizeof(EzType *));
+    tt->nodes = xcalloc((size_t)tt->cap, sizeof(AstNode *));
+    tt->types = xcalloc((size_t)tt->cap, sizeof(EzType *));
     return tt;
 }
 
@@ -52,8 +53,8 @@ static void typetable_grow(TypeTable *tt) {
     EzType **old_types = tt->types;
 
     tt->cap = old_cap * 2;
-    tt->nodes = calloc((size_t)tt->cap, sizeof(AstNode *));
-    tt->types = calloc((size_t)tt->cap, sizeof(EzType *));
+    tt->nodes = xcalloc((size_t)tt->cap, sizeof(AstNode *));
+    tt->types = xcalloc((size_t)tt->cap, sizeof(EzType *));
     tt->count = 0;
 
     for (int i = 0; i < old_cap; i++) {
@@ -137,7 +138,7 @@ static void register_struct(TypeChecker *tc, const char *name,
     const char **field_names, EzType **field_types, int field_count) {
     if (tc->struct_count >= tc->struct_cap) {
         tc->struct_cap = tc->struct_cap ? tc->struct_cap * 2 : 8;
-        tc->structs = realloc(tc->structs, sizeof(StructInfo) * tc->struct_cap);
+        tc->structs = xrealloc(tc->structs, sizeof(StructInfo) * tc->struct_cap);
     }
     StructInfo *si = &tc->structs[tc->struct_count++];
     si->struct_name = name;
@@ -248,7 +249,7 @@ static void register_func(TypeChecker *tc, const char *name,
     EzType **return_types, int return_count) {
     if (tc->func_count >= tc->func_cap) {
         tc->func_cap = tc->func_cap ? tc->func_cap * 2 : 16;
-        tc->funcs = realloc(tc->funcs, sizeof(FuncSig) * tc->func_cap);
+        tc->funcs = xrealloc(tc->funcs, sizeof(FuncSig) * tc->func_cap);
     }
     FuncSig *fs = &tc->funcs[tc->func_count++];
     fs->name = name;
@@ -275,7 +276,7 @@ static char *substitute_wildcard(const char *src, const char *concrete) {
     size_t cl = strlen(concrete);
     size_t len = 0;
     for (const char *c = src; *c; c++) len += (*c == '?') ? cl : 1;
-    char *out = malloc(len + 1);
+    char *out = xmalloc(len + 1);
     char *w = out;
     for (const char *c = src; *c; c++) {
         if (*c == '?') { memcpy(w, concrete, cl); w += cl; }
@@ -398,9 +399,9 @@ static bool record_instantiation(FuncSig *fs, const char *concrete,
     }
     if (fs->instantiation_count >= fs->instantiation_cap) {
         fs->instantiation_cap = fs->instantiation_cap ? fs->instantiation_cap * 2 : 4;
-        fs->instantiations = realloc(fs->instantiations,
+        fs->instantiations = xrealloc(fs->instantiations,
             sizeof(const char *) * fs->instantiation_cap);
-        fs->instantiation_calls = realloc(fs->instantiation_calls,
+        fs->instantiation_calls = xrealloc(fs->instantiation_calls,
             sizeof(AstNode *) * fs->instantiation_cap);
     }
     char *stored = strdup(concrete);
@@ -410,7 +411,7 @@ static bool record_instantiation(FuncSig *fs, const char *concrete,
 
     if (fs->decl && fs->decl->kind == NODE_FUNC_DECL) {
         int n = fs->decl->data.func_decl.instantiation_count;
-        fs->decl->data.func_decl.instantiations = realloc(
+        fs->decl->data.func_decl.instantiations = xrealloc(
             (void *)fs->decl->data.func_decl.instantiations,
             sizeof(const char *) * (size_t)(n + 1));
         fs->decl->data.func_decl.instantiations[n] = stored;
@@ -830,7 +831,7 @@ static int levenshtein(const char *a, const char *b) {
     if (la == 0) return lb;
     if (lb == 0) return la;
     /* Use single-row DP */
-    int *row = malloc(sizeof(int) * (lb + 1));
+    int *row = xmalloc(sizeof(int) * (lb + 1));
     for (int j = 0; j <= lb; j++) row[j] = j;
     for (int i = 1; i <= la; i++) {
         int prev = row[0];
@@ -989,10 +990,10 @@ static void register_enum(TypeChecker *tc, const char *name, bool is_string,
     const char **values, int value_count) {
     if (tc->enum_count >= tc->enum_cap) {
         tc->enum_cap = tc->enum_cap ? tc->enum_cap * 2 : 8;
-        tc->enum_names = realloc(tc->enum_names, sizeof(const char *) * tc->enum_cap);
-        tc->enum_is_string = realloc(tc->enum_is_string, sizeof(bool) * tc->enum_cap);
-        tc->enum_values = realloc(tc->enum_values, sizeof(const char **) * tc->enum_cap);
-        tc->enum_value_counts = realloc(tc->enum_value_counts, sizeof(int) * tc->enum_cap);
+        tc->enum_names = xrealloc(tc->enum_names, sizeof(const char *) * tc->enum_cap);
+        tc->enum_is_string = xrealloc(tc->enum_is_string, sizeof(bool) * tc->enum_cap);
+        tc->enum_values = xrealloc(tc->enum_values, sizeof(const char **) * tc->enum_cap);
+        tc->enum_value_counts = xrealloc(tc->enum_value_counts, sizeof(int) * tc->enum_cap);
     }
     tc->enum_names[tc->enum_count] = name;
     tc->enum_is_string[tc->enum_count] = is_string;
@@ -2965,8 +2966,8 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
                              * name, and prepend the instance as arg[0]. */
                             fn->data.member.object->data.label.value = strdup(sname);
                             int orig_count = node->data.call.arg_count;
-                            AstNode **new_args = malloc(sizeof(AstNode *) * (orig_count + 1));
-                            AstNode *self_arg = calloc(1, sizeof(AstNode));
+                            AstNode **new_args = xmalloc(sizeof(AstNode *) * (orig_count + 1));
+                            AstNode *self_arg = xcalloc(1, sizeof(AstNode));
                             self_arg->kind = NODE_LABEL;
                             self_arg->token = node->token;
                             self_arg->data.label.value = strdup(mod_raw);
@@ -4622,7 +4623,7 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
                 }
                 if (!already) {
                     int n = sdecl->data.struct_decl.instantiation_count;
-                    sdecl->data.struct_decl.instantiations = realloc(
+                    sdecl->data.struct_decl.instantiations = xrealloc(
                         (void *)sdecl->data.struct_decl.instantiations,
                         sizeof(const char *) * (size_t)(n + 1));
                     sdecl->data.struct_decl.instantiations[n] = strdup(binding);
@@ -4763,7 +4764,7 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
             AstNode *obj = node->data.func_ref.function->data.member.object;
             const char *member = node->data.func_ref.function->data.member.member;
             if (obj->kind == NODE_LABEL) {
-                char *prefixed = malloc(strlen(obj->data.label.value) + strlen(member) + 2);
+                char *prefixed = xmalloc(strlen(obj->data.label.value) + strlen(member) + 2);
                 sprintf(prefixed, "%s_%s", obj->data.label.value, member);
                 ref_name = prefixed;
             }
@@ -5777,7 +5778,7 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
                                 }
                                 if (binding) {
                                     int rc = decl->data.func_decl.return_type_count;
-                                    EzType **subbed = malloc(sizeof(EzType *) * (size_t)rc);
+                                    EzType **subbed = xmalloc(sizeof(EzType *) * (size_t)rc);
                                     for (int ri = 0; ri < rc; ri++) {
                                         char *sub = substitute_wildcard(
                                             decl->data.func_decl.return_types[ri], binding);
@@ -5804,7 +5805,7 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
                         Symbol *sym = scope_lookup_local(tc->current_scope,
                             node->data.var_decl.name);
                         if (sym && primary) {
-                            EzType **rt = malloc(sizeof(EzType *) * 2);
+                            EzType **rt = xmalloc(sizeof(EzType *) * 2);
                             rt[0] = primary;
                             rt[1] = type_from_name("Error");
                             sym->ret_types = rt;
@@ -5843,7 +5844,7 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
                     rname = fref->data.label.value;
                 } else if (fref->kind == NODE_MEMBER_EXPR &&
                            fref->data.member.object->kind == NODE_LABEL) {
-                    char *prefixed = malloc(
+                    char *prefixed = xmalloc(
                         strlen(fref->data.member.object->data.label.value) +
                         strlen(fref->data.member.member) + 2);
                     sprintf(prefixed, "%s_%s",
@@ -5872,7 +5873,7 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
                 Symbol *sym = scope_lookup_local(tc->current_scope,
                     node->data.var_decl.name);
                 if (sym && n > 0) {
-                    sym->func_array_refs = calloc((size_t)n, sizeof(const char *));
+                    sym->func_array_refs = xcalloc((size_t)n, sizeof(const char *));
                     sym->func_array_ref_count = n;
                     for (int ei = 0; ei < n; ei++) {
                         AstNode *el = lit->data.array_value.elements[ei];
@@ -5885,7 +5886,7 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
                             size_t plen =
                                 strlen(fref->data.member.object->data.label.value) +
                                 strlen(fref->data.member.member) + 2;
-                            char *pref = malloc(plen);
+                            char *pref = xmalloc(plen);
                             snprintf(pref, plen, "%s_%s",
                                 fref->data.member.object->data.label.value,
                                 fref->data.member.member);
@@ -6352,7 +6353,7 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
                 } else {
                     if (tc->destroyed_arena_count >= tc->destroyed_arena_cap) {
                         tc->destroyed_arena_cap = tc->destroyed_arena_cap ? tc->destroyed_arena_cap * 2 : 8;
-                        tc->destroyed_arenas = realloc(tc->destroyed_arenas,
+                        tc->destroyed_arenas = xrealloc(tc->destroyed_arenas,
                             (size_t)tc->destroyed_arena_cap * sizeof(const char *));
                     }
                     tc->destroyed_arenas[tc->destroyed_arena_count++] = arena_name;
@@ -6385,7 +6386,7 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
                 } else {
                     if (tc->destroyed_arena_count >= tc->destroyed_arena_cap) {
                         tc->destroyed_arena_cap = tc->destroyed_arena_cap ? tc->destroyed_arena_cap * 2 : 8;
-                        tc->destroyed_arenas = realloc(tc->destroyed_arenas,
+                        tc->destroyed_arenas = xrealloc(tc->destroyed_arenas,
                             (size_t)tc->destroyed_arena_cap * sizeof(const char *));
                     }
                     tc->destroyed_arenas[tc->destroyed_arena_count++] = arena_name;
@@ -6746,8 +6747,8 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
         }
 
         if (node->data.func_decl.return_type_count > 0) {
-            tc->current_return_types = malloc(sizeof(EzType *) * node->data.func_decl.return_type_count);
-            tc->current_return_type_names = malloc(sizeof(const char *) * node->data.func_decl.return_type_count);
+            tc->current_return_types = xmalloc(sizeof(EzType *) * node->data.func_decl.return_type_count);
+            tc->current_return_type_names = xmalloc(sizeof(const char *) * node->data.func_decl.return_type_count);
             tc->current_return_count = node->data.func_decl.return_type_count;
             for (int i = 0; i < node->data.func_decl.return_type_count; i++) {
                 tc->current_return_types[i] = tc_type_from_name(tc, node->data.func_decl.return_types[i]);
@@ -6898,7 +6899,7 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
         for (int j = 0; j < node->data.using_stmt.count; j++) {
             if (tc->using_module_count >= tc->using_module_cap) {
                 tc->using_module_cap = tc->using_module_cap ? tc->using_module_cap * 2 : 8;
-                tc->using_modules = realloc(tc->using_modules,
+                tc->using_modules = xrealloc(tc->using_modules,
                     sizeof(const char *) * (size_t)tc->using_module_cap);
             }
             tc->using_modules[tc->using_module_count++] = node->data.using_stmt.modules[j];
@@ -7146,11 +7147,11 @@ static void register_declarations(TypeChecker *tc, AstNode *program) {
                 if (item->module || item->alias) {
                     if (tc->import_count >= tc->import_cap) {
                         tc->import_cap = tc->import_cap ? tc->import_cap * 2 : 16;
-                        tc->imported_modules = realloc(tc->imported_modules, sizeof(const char *) * tc->import_cap);
-                        tc->import_files = realloc(tc->import_files, sizeof(const char *) * tc->import_cap);
-                        tc->import_lines = realloc(tc->import_lines, sizeof(int) * tc->import_cap);
-                        tc->import_used = realloc(tc->import_used, sizeof(bool) * tc->import_cap);
-                        tc->import_is_stdlib = realloc(tc->import_is_stdlib, sizeof(bool) * tc->import_cap);
+                        tc->imported_modules = xrealloc(tc->imported_modules, sizeof(const char *) * tc->import_cap);
+                        tc->import_files = xrealloc(tc->import_files, sizeof(const char *) * tc->import_cap);
+                        tc->import_lines = xrealloc(tc->import_lines, sizeof(int) * tc->import_cap);
+                        tc->import_used = xrealloc(tc->import_used, sizeof(bool) * tc->import_cap);
+                        tc->import_is_stdlib = xrealloc(tc->import_is_stdlib, sizeof(bool) * tc->import_cap);
                     }
                     tc->imported_modules[tc->import_count] = item->alias ? item->alias : item->module;
                     tc->import_files[tc->import_count] = stmt->token.file; /* NULL = main file */
@@ -7163,8 +7164,8 @@ static void register_declarations(TypeChecker *tc, AstNode *program) {
                 if (item->alias && item->module && strcmp(item->alias, item->module) != 0) {
                     if (tc->alias_count >= tc->alias_cap) {
                         tc->alias_cap = tc->alias_cap ? tc->alias_cap * 2 : 8;
-                        tc->alias_names = realloc(tc->alias_names, sizeof(const char *) * tc->alias_cap);
-                        tc->alias_modules = realloc(tc->alias_modules, sizeof(const char *) * tc->alias_cap);
+                        tc->alias_names = xrealloc(tc->alias_names, sizeof(const char *) * tc->alias_cap);
+                        tc->alias_modules = xrealloc(tc->alias_modules, sizeof(const char *) * tc->alias_cap);
                     }
                     tc->alias_names[tc->alias_count] = item->alias;
                     tc->alias_modules[tc->alias_count] = item->module;
@@ -7247,7 +7248,7 @@ static void register_declarations(TypeChecker *tc, AstNode *program) {
                 NODE_FILE(tc, stmt), stmt->token.line, stmt->token.column, 0);
         }
         int vc = stmt->data.enum_decl.value_count;
-        const char **vnames = malloc(sizeof(const char *) * (vc ? vc : 1));
+        const char **vnames = xmalloc(sizeof(const char *) * (vc ? vc : 1));
         for (int j = 0; j < vc; j++) {
             vnames[j] = stmt->data.enum_decl.values[j].name;
         }
@@ -7264,9 +7265,8 @@ static void register_declarations(TypeChecker *tc, AstNode *program) {
                 diag_error_codef(tc->diag, "E2067", NODE_FILE(tc, stmt), stmt->token.line, stmt->token.column, 0, STRUCT_DISPLAY_NAME(stmt));
             }
             int fc = stmt->data.struct_decl.field_count;
-            const char **fnames = malloc(sizeof(const char *) * (fc ? fc : 1));
-            EzType **ftypes = malloc(sizeof(EzType *) * (fc ? fc : 1));
-            if (!fnames || !ftypes) { free(fnames); free(ftypes); continue; }
+            const char **fnames = xmalloc(sizeof(const char *) * (fc ? fc : 1));
+            EzType **ftypes = xmalloc(sizeof(EzType *) * (fc ? fc : 1));
             for (int j = 0; j < fc; j++) {
                 fnames[j] = stmt->data.struct_decl.fields[j].name;
                 ftypes[j] = tc_type_from_name(tc, stmt->data.struct_decl.fields[j].type_name);
@@ -7388,19 +7388,17 @@ static void register_declarations(TypeChecker *tc, AstNode *program) {
                     }
                 }
                 int pc = fn->data.func_decl.param_count;
-                EzType **ptypes = malloc(sizeof(EzType *) * (pc ? pc : 1));
-                if (!ptypes) continue;
+                EzType **ptypes = xmalloc(sizeof(EzType *) * (pc ? pc : 1));
                 for (int k = 0; k < pc; k++) {
                     ptypes[k] = tc_type_from_name(tc, fn->data.func_decl.params[k].type_name);
                 }
                 int rc = fn->data.func_decl.return_type_count;
-                EzType **rtypes = malloc(sizeof(EzType *) * (rc ? rc : 1));
-                if (!rtypes) { free(ptypes); continue; }
+                EzType **rtypes = xmalloc(sizeof(EzType *) * (rc ? rc : 1));
                 for (int k = 0; k < rc; k++) {
                     rtypes[k] = tc_type_from_name(tc, fn->data.func_decl.return_types[k]);
                 }
                 /* Register with prefixed name: StructName_funcName */
-                char *prefixed = malloc(strlen(stmt->data.struct_decl.name) +
+                char *prefixed = xmalloc(strlen(stmt->data.struct_decl.name) +
                     strlen(fn->data.func_decl.name) + 2);
                 sprintf(prefixed, "%s_%s", stmt->data.struct_decl.name, fn->data.func_decl.name);
                 register_func(tc, prefixed, ptypes, pc, rtypes, rc);
@@ -7413,16 +7411,14 @@ static void register_declarations(TypeChecker *tc, AstNode *program) {
 
         if (stmt->kind == NODE_FUNC_DECL) {
             int pc = stmt->data.func_decl.param_count;
-            EzType **ptypes = malloc(sizeof(EzType *) * (pc ? pc : 1));
-            if (!ptypes) continue;
+            EzType **ptypes = xmalloc(sizeof(EzType *) * (pc ? pc : 1));
             for (int j = 0; j < pc; j++) {
                 ptypes[j] = tc_type_from_name(tc, stmt->data.func_decl.params[j].type_name);
                 tc_mark_type_module_used(tc, stmt->data.func_decl.params[j].type_name);
             }
 
             int rc = stmt->data.func_decl.return_type_count;
-            EzType **rtypes = malloc(sizeof(EzType *) * (rc ? rc : 1));
-            if (!rtypes) { free(ptypes); continue; }
+            EzType **rtypes = xmalloc(sizeof(EzType *) * (rc ? rc : 1));
             for (int j = 0; j < rc; j++) {
                 rtypes[j] = tc_type_from_name(tc, stmt->data.func_decl.return_types[j]);
                 tc_mark_type_module_used(tc, stmt->data.func_decl.return_types[j]);
@@ -7494,7 +7490,7 @@ static void register_declarations(TypeChecker *tc, AstNode *program) {
 /* --- Public API --- */
 
 TypeChecker *typechecker_create(DiagnosticList *diag, const char *file) {
-    TypeChecker *tc = calloc(1, sizeof(TypeChecker));
+    TypeChecker *tc = xcalloc(1, sizeof(TypeChecker));
     tc->diag = diag;
     tc->file = file;
     tc->current_scope = scope_create(NULL);
@@ -7552,7 +7548,7 @@ void typechecker_check(TypeChecker *tc, AstNode *program) {
                 }
                 if (tc->using_module_count >= tc->using_module_cap) {
                     tc->using_module_cap = tc->using_module_cap ? tc->using_module_cap * 2 : 8;
-                    tc->using_modules = realloc(tc->using_modules,
+                    tc->using_modules = xrealloc(tc->using_modules,
                         sizeof(const char *) * (size_t)tc->using_module_cap);
                 }
                 tc->using_modules[tc->using_module_count++] = stmt->data.using_stmt.modules[j];
@@ -7571,7 +7567,7 @@ void typechecker_check(TypeChecker *tc, AstNode *program) {
                 if (item->module) {
                     if (tc->using_module_count >= tc->using_module_cap) {
                         tc->using_module_cap = tc->using_module_cap ? tc->using_module_cap * 2 : 8;
-                        tc->using_modules = realloc(tc->using_modules,
+                        tc->using_modules = xrealloc(tc->using_modules,
                             sizeof(const char *) * (size_t)tc->using_module_cap);
                     }
                     tc->using_modules[tc->using_module_count++] = item->module;
@@ -7685,8 +7681,8 @@ void typechecker_check(TypeChecker *tc, AstNode *program) {
             EzType **ret_types = NULL;
             const char **ret_names = NULL;
             if (rc > 0) {
-                ret_types = malloc(sizeof(EzType *) * (size_t)rc);
-                ret_names = malloc(sizeof(const char *) * (size_t)rc);
+                ret_types = xmalloc(sizeof(EzType *) * (size_t)rc);
+                ret_names = xmalloc(sizeof(const char *) * (size_t)rc);
                 for (int ri = 0; ri < rc; ri++) {
                     char *sub = substitute_wildcard(
                         decl->data.func_decl.return_types[ri], concrete);

--- a/ezc/src/typechecker/types.c
+++ b/ezc/src/typechecker/types.c
@@ -7,6 +7,7 @@
 
 #include "types.h"
 #include "../util/constants.h"
+#include "../util/xalloc.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -92,7 +93,7 @@ static void split_top_commas(const char *src, int start, int end,
     *out_arr = NULL;
     if (end <= start) return;
     int cap = 4;
-    char **arr = (char **)malloc(sizeof(char *) * (size_t)cap);
+    char **arr = (char **)xmalloc(sizeof(char *) * (size_t)cap);
     int n = 0;
     int depth = 0;
     int seg_start = start;
@@ -102,12 +103,12 @@ static void split_top_commas(const char *src, int start, int end,
         else if (c == ')' || c == ']') depth--;
         if (depth == 0 && (c == ',' || i == end)) {
             int seg_len = i - seg_start;
-            char *seg = (char *)malloc((size_t)seg_len + 1);
+            char *seg = (char *)xmalloc((size_t)seg_len + 1);
             memcpy(seg, src + seg_start, (size_t)seg_len);
             seg[seg_len] = '\0';
             if (n == cap) {
                 cap *= 2;
-                arr = (char **)realloc(arr, sizeof(char *) * (size_t)cap);
+                arr = (char **)xrealloc(arr, sizeof(char *) * (size_t)cap);
             }
             arr[n++] = seg;
             seg_start = i + 1;
@@ -123,7 +124,7 @@ static EzFuncSig *parse_func_sig(const char *name) {
     if (strncmp(name, "func(", 5) != 0) return NULL;
     int rparen = find_matching_paren(name, 4);
     if (rparen < 0) return NULL;
-    EzFuncSig *sig = (EzFuncSig *)malloc(sizeof(EzFuncSig));
+    EzFuncSig *sig = (EzFuncSig *)xmalloc(sizeof(EzFuncSig));
     sig->param_count = 0;
     sig->param_types = NULL;
     sig->param_mutable = NULL;
@@ -136,8 +137,8 @@ static EzFuncSig *parse_func_sig(const char *name) {
     split_top_commas(name, 5, rparen, &raw_count, &raw_params);
     sig->param_count = raw_count;
     if (raw_count > 0) {
-        sig->param_types = (const char **)malloc(sizeof(char *) * (size_t)raw_count);
-        sig->param_mutable = (bool *)malloc(sizeof(bool) * (size_t)raw_count);
+        sig->param_types = (const char **)xmalloc(sizeof(char *) * (size_t)raw_count);
+        sig->param_mutable = (bool *)xmalloc(sizeof(bool) * (size_t)raw_count);
         for (int i = 0; i < raw_count; i++) {
             const char *p = raw_params[i];
             if (p[0] == '&') {
@@ -164,7 +165,7 @@ static EzFuncSig *parse_func_sig(const char *name) {
             split_top_commas(ret, 1, ret_len - 1, &rcount, &rets);
             sig->return_count = rcount;
             if (rcount > 0) {
-                sig->return_types = (const char **)malloc(sizeof(char *) * (size_t)rcount);
+                sig->return_types = (const char **)xmalloc(sizeof(char *) * (size_t)rcount);
                 for (int i = 0; i < rcount; i++) {
                     sig->return_types[i] = rets[i];
                 }
@@ -172,7 +173,7 @@ static EzFuncSig *parse_func_sig(const char *name) {
             free(rets);
         } else if (strcmp(ret, "void") != 0) {
             sig->return_count = 1;
-            sig->return_types = (const char **)malloc(sizeof(char *));
+            sig->return_types = (const char **)xmalloc(sizeof(char *));
             sig->return_types[0] = strdup(ret);
         }
     }
@@ -317,8 +318,7 @@ EzType *type_from_name(const char *name) {
     if (name[0] == '[') {
         size_t len = strlen(name);
         if (len > 2 && name[len - 1] == ']') {
-            char *elem = malloc(len - 1);
-            if (!elem) return &TYPE_UNKNOWN;
+            char *elem = xmalloc(len - 1);
             memcpy(elem, name + 1, len - 2);
             elem[len - 2] = '\0';
             /* Strip ",N" suffix for fixed-size arrays like [string,3] */
@@ -338,8 +338,7 @@ EzType *type_from_name(const char *name) {
         const char *colon = strchr(start, ':');
         if (colon) {
             size_t klen = (size_t)(colon - start);
-            char *key = malloc(klen + 1);
-            if (!key) return &TYPE_UNKNOWN;
+            char *key = xmalloc(klen + 1);
             memcpy(key, start, klen);
             key[klen] = '\0';
             t->key_type = key;
@@ -347,8 +346,7 @@ EzType *type_from_name(const char *name) {
             const char *vstart = colon + 1;
             size_t vlen = strlen(vstart);
             if (vlen > 0 && vstart[vlen - 1] == ']') vlen--;
-            char *val = malloc(vlen + 1);
-            if (!val) { free(key); return &TYPE_UNKNOWN; }
+            char *val = xmalloc(vlen + 1);
             memcpy(val, vstart, vlen);
             val[vlen] = '\0';
             t->value_type = val;
@@ -364,7 +362,7 @@ EzType *type_from_name(const char *name) {
             /* Build prefixed name: mod.Type → mod_Type */
             size_t prefix_len = (size_t)(dot - name);
             size_t base_len = strlen(base);
-            char *prefixed = malloc(prefix_len + 1 + base_len + 1);
+            char *prefixed = xmalloc(prefix_len + 1 + base_len + 1);
             memcpy(prefixed, name, prefix_len);
             prefixed[prefix_len] = '_';
             memcpy(prefixed + prefix_len + 1, base, base_len + 1);

--- a/ezc/src/typechecker/types.c
+++ b/ezc/src/typechecker/types.c
@@ -239,62 +239,55 @@ const char *type_name(EzType *t) {
     return t->name;
 }
 
+/* Builtin type-name dispatch table. MUST stay sorted lexicographically by
+ * name (uppercase precedes lowercase in ASCII), validated by bsearch. */
+typedef struct {
+    const char *name;
+    EzType *singleton;   /* non-NULL: return this singleton directly */
+    int alloc_kind;      /* used when singleton is NULL: pool-alloc with this kind */
+    const char *alloc_name; /* if non-NULL, set t->name to this literal instead of strdup(name) */
+} BuiltinTypeEntry;
+
+static BuiltinTypeEntry builtin_types[] = {
+    { "Error",  NULL,         TK_ERROR,   "Error" },
+    { "bool",   &TYPE_BOOL,   0, NULL },
+    { "byte",   &TYPE_BYTE,   0, NULL },
+    { "char",   &TYPE_CHAR,   0, NULL },
+    { "f32",    NULL,         TK_FLOAT,   NULL },
+    { "f64",    NULL,         TK_FLOAT,   NULL },
+    { "float",  &TYPE_FLOAT,  0, NULL },
+    { "func",   NULL,         TK_UNKNOWN, "func" },
+    { "i128",   NULL,         TK_INT,     NULL },
+    { "i16",    NULL,         TK_INT,     NULL },
+    { "i256",   NULL,         TK_INT,     NULL },
+    { "i32",    NULL,         TK_INT,     NULL },
+    { "i64",    NULL,         TK_INT,     NULL },
+    { "i8",     NULL,         TK_INT,     NULL },
+    { "int",    &TYPE_INT,    0, NULL },
+    { "nil",    &TYPE_NIL,    0, NULL },
+    { "string", &TYPE_STRING, 0, NULL },
+    { "u128",   NULL,         TK_UINT,    NULL },
+    { "u16",    NULL,         TK_UINT,    NULL },
+    { "u256",   NULL,         TK_UINT,    NULL },
+    { "u32",    NULL,         TK_UINT,    NULL },
+    { "u64",    NULL,         TK_UINT,    NULL },
+    { "u8",     NULL,         TK_UINT,    NULL },
+    { "uint",   &TYPE_UINT,   0, NULL },
+    { "void",   &TYPE_VOID,   0, NULL },
+};
+
+#define BUILTIN_TYPES_COUNT (sizeof(builtin_types) / sizeof(builtin_types[0]))
+
+static int builtin_type_cmp(const void *a, const void *b) {
+    return strcmp(((const BuiltinTypeEntry *)a)->name,
+                  ((const BuiltinTypeEntry *)b)->name);
+}
+
 EzType *type_from_name(const char *name) {
     if (!name) return &TYPE_UNKNOWN;
 
-    if (strcmp(name, "int") == 0)    return &TYPE_INT;
-    if (strcmp(name, "uint") == 0)   return &TYPE_UINT;
-    if (strcmp(name, "float") == 0)  return &TYPE_FLOAT;
-
-    /* Sized integer and float types: same kind as parent but preserve name */
-    if (strcmp(name, "i8") == 0 || strcmp(name, "i16") == 0 ||
-        strcmp(name, "i32") == 0 || strcmp(name, "i64") == 0) {
-        EzType *t = type_alloc();
-        t->kind = TK_INT;
-        t->name = strdup(name);
-        return t;
-    }
-    if (strcmp(name, "i128") == 0 || strcmp(name, "i256") == 0) {
-        EzType *t = type_alloc();
-        t->kind = TK_INT;
-        t->name = strdup(name);
-        return t;
-    }
-    if (strcmp(name, "u8") == 0 || strcmp(name, "u16") == 0 ||
-        strcmp(name, "u32") == 0 || strcmp(name, "u64") == 0) {
-        EzType *t = type_alloc();
-        t->kind = TK_UINT;
-        t->name = strdup(name);
-        return t;
-    }
-    if (strcmp(name, "u128") == 0 || strcmp(name, "u256") == 0) {
-        EzType *t = type_alloc();
-        t->kind = TK_UINT;
-        t->name = strdup(name);
-        return t;
-    }
-    if (strcmp(name, "f32") == 0 || strcmp(name, "f64") == 0) {
-        EzType *t = type_alloc();
-        t->kind = TK_FLOAT;
-        t->name = strdup(name);
-        return t;
-    }
-    if (strcmp(name, "bool") == 0)   return &TYPE_BOOL;
-    if (strcmp(name, "char") == 0)   return &TYPE_CHAR;
-    if (strcmp(name, "byte") == 0)   return &TYPE_BYTE;
-    if (strcmp(name, "string") == 0) return &TYPE_STRING;
-    if (strcmp(name, "void") == 0)   return &TYPE_VOID;
-    if (strcmp(name, "nil") == 0)    return &TYPE_NIL;
-    /* Bare "func" is no longer a valid type — the parser rejects it before
-     * reaching here. Defensive fallback: model as TK_UNKNOWN so downstream
-     * code doesn't crash if it slips through. */
-    if (strcmp(name, "func") == 0) {
-        EzType *t = type_alloc();
-        t->kind = TK_UNKNOWN;
-        t->name = "func";
-        return t;
-    }
-    /* Typed function reference: "func(p1,&p2)->R" */
+    /* Typed function reference: "func(p1,&p2)->R" — checked before bsearch
+     * so "func(...)" doesn't get conflated with the bare "func" entry. */
     if (strncmp(name, "func(", 5) == 0) {
         EzType *t = type_alloc();
         t->kind = TK_FUNCTION;
@@ -302,10 +295,15 @@ EzType *type_from_name(const char *name) {
         t->func_sig = parse_func_sig(name);
         return t;
     }
-    if (strcmp(name, "Error") == 0) {
+
+    BuiltinTypeEntry key = { name, NULL, 0, NULL };
+    BuiltinTypeEntry *hit = bsearch(&key, builtin_types, BUILTIN_TYPES_COUNT,
+                                    sizeof(BuiltinTypeEntry), builtin_type_cmp);
+    if (hit) {
+        if (hit->singleton) return hit->singleton;
         EzType *t = type_alloc();
-        t->kind = TK_ERROR;
-        t->name = "Error";
+        t->kind = hit->alloc_kind;
+        t->name = hit->alloc_name ? hit->alloc_name : strdup(name);
         return t;
     }
 

--- a/ezc/src/util/error.c
+++ b/ezc/src/util/error.c
@@ -8,6 +8,7 @@
 #include "error.h"
 #include "error_codes.h"
 #include "constants.h"
+#include "xalloc.h"
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -80,7 +81,8 @@ static const char *read_file_to_string(const char *path) {
 /* --- DiagnosticList management --- */
 
 DiagnosticList *diag_create(void) {
-    DiagnosticList *dl = calloc(1, sizeof(DiagnosticList));
+    DiagnosticList *dl = xmalloc(sizeof(DiagnosticList));
+    memset(dl, 0, sizeof(DiagnosticList));
     dl->use_color = isatty(STDERR_FILENO);
     return dl;
 }
@@ -100,7 +102,7 @@ static void diag_add(DiagnosticList *dl, Severity sev, const char *code,
 
     if (dl->count >= dl->cap) {
         dl->cap = dl->cap ? dl->cap * 2 : EZ_DIAG_INITIAL_CAP;
-        dl->items = realloc(dl->items, sizeof(Diagnostic) * dl->cap);
+        dl->items = xrealloc(dl->items, sizeof(Diagnostic) * dl->cap);
     }
 
     Diagnostic *d = &dl->items[dl->count++];

--- a/ezc/src/util/error_codes.c
+++ b/ezc/src/util/error_codes.c
@@ -11,12 +11,14 @@
  */
 
 #include "error_codes.h"
+#include <stdlib.h>
 #include <string.h>
 
-const char *ez_error_message(const char *code) {
-    if (!code) return NULL;
-#define EZ_ERROR(c, cat, msg) if (strcmp(code, c) == 0) return msg;
-#define EZ_WARNING(c, cat, msg) if (strcmp(code, c) == 0) return msg;
+typedef struct { const char *code; const char *msg; } ErrorEntry;
+
+static ErrorEntry entries[] = {
+#define EZ_ERROR(c, cat, msg) { c, msg },
+#define EZ_WARNING(c, cat, msg) { c, msg },
     EZ_LEXER_ERRORS
     EZ_PARSER_ERRORS
     EZ_TYPE_ERRORS
@@ -27,5 +29,23 @@ const char *ez_error_message(const char *code) {
     EZ_WARNINGS
 #undef EZ_ERROR
 #undef EZ_WARNING
-    return NULL;
+};
+
+#define ENTRY_COUNT (sizeof(entries) / sizeof(entries[0]))
+
+static int entry_cmp(const void *a, const void *b) {
+    return strcmp(((const ErrorEntry *)a)->code, ((const ErrorEntry *)b)->code);
+}
+
+static int sorted = 0;
+
+const char *ez_error_message(const char *code) {
+    if (!code) return NULL;
+    if (!sorted) {
+        qsort(entries, ENTRY_COUNT, sizeof(ErrorEntry), entry_cmp);
+        sorted = 1;
+    }
+    ErrorEntry key = { code, NULL };
+    ErrorEntry *hit = bsearch(&key, entries, ENTRY_COUNT, sizeof(ErrorEntry), entry_cmp);
+    return hit ? hit->msg : NULL;
 }

--- a/ezc/src/util/xalloc.h
+++ b/ezc/src/util/xalloc.h
@@ -1,0 +1,37 @@
+/*
+ * xalloc.h - allocation wrappers that abort on OOM
+ *
+ * Compiler-internal allocations are not user-recoverable; on failure
+ * we print to stderr and exit. Mirrors the pattern already inlined in
+ * buf.c and arena.c.
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef EZC_XALLOC_H
+#define EZC_XALLOC_H
+
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static inline void *xrealloc(void *ptr, size_t size) {
+    void *p = realloc(ptr, size);
+    if (!p) {
+        fprintf(stderr, "ezc: out of memory\n");
+        exit(1);
+    }
+    return p;
+}
+
+static inline void *xmalloc(size_t size) {
+    void *p = malloc(size);
+    if (!p) {
+        fprintf(stderr, "ezc: out of memory\n");
+        exit(1);
+    }
+    return p;
+}
+
+#endif

--- a/ezc/src/util/xalloc.h
+++ b/ezc/src/util/xalloc.h
@@ -34,4 +34,13 @@ static inline void *xmalloc(size_t size) {
     return p;
 }
 
+static inline void *xcalloc(size_t nmemb, size_t size) {
+    void *p = calloc(nmemb, size);
+    if (!p) {
+        fprintf(stderr, "ezc: out of memory\n");
+        exit(1);
+    }
+    return p;
+}
+
 #endif


### PR DESCRIPTION

- Free four leaked malloc'd buffers in codegen module/func-ref resolution (`ns_name`, `mangled`, `rn`, `check_name`/`prefix`)
- New `util/xalloc.h` (`xmalloc`/`xcalloc`/`xrealloc`) — abort-on-OOM helpers matching the inline pattern already in `buf.c`/`arena.c`
- Routed all unchecked `malloc`/`calloc`/`realloc` calls in `codegen.c`, `typechecker.c`, `types.c`, `scope.c`, `error.c` through the xalloc helpers
- Removed dead "skip on OOM" branches in typechecker that were silently producing incomplete state on allocation failure

### Performance
- `error_codes.c`: chained `strcmp` lookup → sorted `bsearch`
- `typechecker/types.c::type_from_name`: ~25 chained `strcmp`s → static sorted bsearch table dispatching singletons + sized variants in one shot
- `codegen.c`: replaced `O(struct_count × field_count)` scan in the member-call fallback heuristic with a lazily-built `(field_name, struct_name)` index over only func-typed fields
- `codegen.c::find_func`: linear scan → separate sorted view (`funcs_by_name`) + bsearch. `cg->all_funcs` keeps insertion order so emission and prefix-match scans 

- `stream` arg in non-container char print (`emitf` had 2 `%s` and 3 args)
- heap-allocated `mangled` buffer in monomorphisation forward-decl loop instead of letting a stack address briefly live in the AST
- replaced two duplicated case-insensitive `true`/`false` parsers with `strncasecmp`
-`io.copy_file` now creates the destination with mode 0644 via `open()`+`fdopen()` instead of `fopen()`'s 0666-mod-umask default
— `ez_arrays.remove_float` needs bit-equal lookup; `fmt_shortest_float` is the canonical round-trip-precision idiom