### PR TITLE
fix(stdlib/arrays): bounds-check insert_at and drop 32-byte stack buffer

### DIFF
--- a/ezc/src/stdlib/ez_arrays.c
+++ b/ezc/src/stdlib/ez_arrays.c
@@ -17,12 +17,35 @@ void ez_arrays_append(EzArena *arena, EzArray *arr, const void *value) {
 }
 
 void ez_arrays_insert_at(EzArena *arena, EzArray *arr, int32_t index, const void *value) {
-    char zero[32] = {0};
-    ez_array_push(arena, arr, zero);
-    char *data = (char *)arr->data;
+    if (index < 0 || index > arr->len) {
+        ez_panic(__FILE__, __LINE__,
+            "arrays.insert_at: index %d is out of bounds for an array of length %d",
+            index, arr->len);
+    }
+
+    /* Grow if needed — same policy as ez_array_push */
+    if (arr->len >= arr->cap) {
+        int32_t new_cap = arr->cap < EZ_ARRAY_MIN_CAP ? EZ_ARRAY_MIN_CAP : arr->cap * 2;
+        if (new_cap < arr->cap) {
+            fprintf(stderr, "EZ runtime: array capacity overflow\n");
+            exit(1);
+        }
+        void *new_data = ez_arena_alloc(arena, (size_t)new_cap * (size_t)arr->elem_size);
+        if (arr->data && arr->len > 0) {
+            memcpy(new_data, arr->data, (size_t)arr->len * (size_t)arr->elem_size);
+        }
+        arr->data = new_data;
+        arr->cap = new_cap;
+    }
+
     size_t es = (size_t)arr->elem_size;
-    memmove(data + (index + 1) * es, data + index * es, (arr->len - 1 - index) * es);
+    char *data = (char *)arr->data;
+    if (index < arr->len) {
+        memmove(data + (index + 1) * es, data + index * es,
+                (size_t)(arr->len - index) * es);
+    }
     memcpy(data + index * es, value, es);
+    arr->len++;
 }
 
 void ez_arrays_prepend(EzArena *arena, EzArray *arr, const void *value) {

--- a/integration-tests/fail/errors/panic_insert_at_negative_index.ez
+++ b/integration-tests/fail/errors/panic_insert_at_negative_index.ez
@@ -1,0 +1,11 @@
+/*
+ * Error Test: arrays.insert_at runtime panic on negative index
+ * Expected: panic with "out of bounds"
+ */
+
+import @arrays
+
+do main() {
+    mut xs [int] = {1, 2, 3}
+    arrays.insert_at(xs, -5, 999)
+}

--- a/integration-tests/fail/errors/panic_insert_at_oob.ez
+++ b/integration-tests/fail/errors/panic_insert_at_oob.ez
@@ -1,0 +1,11 @@
+/*
+ * Error Test: arrays.insert_at runtime panic on positive out-of-bounds index
+ * Expected: panic with "out of bounds"
+ */
+
+import @arrays
+
+do main() {
+    mut xs [int] = {1, 2, 3}
+    arrays.insert_at(xs, 100, 999)
+}

--- a/integration-tests/pass/stdlib/arrays.ez
+++ b/integration-tests/pass/stdlib/arrays.ez
@@ -142,6 +142,16 @@ do main() {
         failed += 1
     }
 
+    mut ins_end [int] = {1, 2}
+    arrays.insert_at(ins_end, 2, 3)
+    if len(ins_end) == 3 && ins_end[2] == 3 {
+        println("  [PASS] arrays.insert_at at len (append)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] arrays.insert_at at len: got ${ins_end}")
+        failed += 1
+    }
+
     // ==================== arrays.reverse ====================
     println("  -- arrays.reverse --")
 


### PR DESCRIPTION
Fixes #1622. Rewrites `ez_arrays_insert_at` to bounds-check `index` against `[0, len]` before any memory access and to grow the array directly instead of using the placeholder `char zero[32]` push trick, which read past the end of the stack buffer for any element type larger than 32 bytes. Adds two fail tests (positive OOB and negative index) plus an append-at-`len` case in `pass/stdlib/arrays.ez`.