### PR TITLE
fix(stdlib): handle ftell failure on non-seekable inputs in read_file

### DIFF
--- a/ezc/src/main.c
+++ b/ezc/src/main.c
@@ -62,19 +62,61 @@ static char *read_file(const char *path) {
         return NULL;
     }
 
-    fseek(f, 0, SEEK_END);
-    long size = ftell(f);
-    fseek(f, 0, SEEK_SET);
+    /* Try the seekable fast path. Fall through to streaming on any
+     * failure: pipes, FIFOs, /dev/stdin, /proc, sockets, etc. all make
+     * ftell return -1, which previously wrapped (size_t)-1 + 1 to 0
+     * and caused fread to write past the heap allocation. */
+    long size = -1;
+    if (fseek(f, 0, SEEK_END) == 0) {
+        size = ftell(f);
+        if (size >= 0) (void)fseek(f, 0, SEEK_SET);
+    }
 
-    char *buf = malloc((size_t)size + 1);
+    if (size >= 0) {
+        char *buf = malloc((size_t)size + 1);
+        if (!buf) {
+            fprintf(stderr, "ez: out of memory\n");
+            fclose(f);
+            return NULL;
+        }
+        size_t read = fread(buf, 1, (size_t)size, f);
+        buf[read] = '\0';
+        fclose(f);
+        return buf;
+    }
+
+    /* Streaming fallback for non-seekable inputs. */
+    clearerr(f);
+    size_t cap = 4096;
+    size_t len = 0;
+    char *buf = malloc(cap);
     if (!buf) {
         fprintf(stderr, "ez: out of memory\n");
         fclose(f);
         return NULL;
     }
-
-    size_t read = fread(buf, 1, (size_t)size, f);
-    buf[read] = '\0';
+    for (;;) {
+        if (len == cap) {
+            size_t new_cap = cap * 2;
+            char *new_buf = realloc(buf, new_cap);
+            if (!new_buf) {
+                free(buf);
+                fclose(f);
+                fprintf(stderr, "ez: out of memory\n");
+                return NULL;
+            }
+            buf = new_buf;
+            cap = new_cap;
+        }
+        size_t got = fread(buf + len, 1, cap - len, f);
+        if (got == 0) break;
+        len += got;
+    }
+    if (len + 1 > cap) {
+        char *grow = realloc(buf, len + 1);
+        if (grow) buf = grow;
+    }
+    buf[len] = '\0';
     fclose(f);
     return buf;
 }

--- a/ezc/src/stdlib/ez_io.c
+++ b/ezc/src/stdlib/ez_io.c
@@ -157,15 +157,55 @@ EzString ez_io_normalize(EzArena *arena, EzString path) {
 EzString ez_io_read_file(EzArena *arena, EzString path) {
     FILE *f = fopen(path.data, "rb");
     if (!f) return ez_string_lit("");
-    fseek(f, 0, SEEK_END);
-    long size = ftell(f);
-    fseek(f, 0, SEEK_SET);
-    char *buf = ez_arena_alloc(arena, (size_t)size + 1);
-    size_t read = fread(buf, 1, (size_t)size, f);
-    buf[read] = '\0';
+
+    /* Try to size the buffer from the file. Falls back to streaming
+     * when the file isn't seekable (pipes, FIFOs, /dev/stdin, /proc,
+     * sockets). On those, ftell returns -1, which used to wrap to
+     * (size_t)-1 + 1 = 0 and let fread write past the arena slot. */
+    long size = -1;
+    if (fseek(f, 0, SEEK_END) == 0) {
+        size = ftell(f);
+        if (size >= 0) (void)fseek(f, 0, SEEK_SET);
+    }
+
+    if (size >= 0 && size <= INT32_MAX) {
+        char *buf = ez_arena_alloc(arena, (size_t)size + 1);
+        size_t read = fread(buf, 1, (size_t)size, f);
+        buf[read] = '\0';
+        fclose(f);
+        return (EzString){ buf, (int32_t)read };
+    }
+
+    /* Streaming fallback for non-seekable inputs. */
+    clearerr(f);
+    size_t cap = 4096;
+    size_t len = 0;
+    char *buf = ez_arena_alloc(arena, cap);
+    for (;;) {
+        if (len == cap) {
+            if (cap > (size_t)INT32_MAX / 2) {
+                fclose(f);
+                ez_panic(__FILE__, __LINE__,
+                    "io.read_file: input exceeds maximum string length");
+            }
+            size_t new_cap = cap * 2;
+            char *new_buf = ez_arena_alloc(arena, new_cap);
+            memcpy(new_buf, buf, len);
+            buf = new_buf;
+            cap = new_cap;
+        }
+        size_t got = fread(buf + len, 1, cap - len, f);
+        if (got == 0) break;
+        len += got;
+    }
+    if (len == cap) {
+        char *grow = ez_arena_alloc(arena, len + 1);
+        memcpy(grow, buf, len);
+        buf = grow;
+    }
+    buf[len] = '\0';
     fclose(f);
-    EzString s = { buf, (int32_t)read };
-    return s;
+    return (EzString){ buf, (int32_t)len };
 }
 
 bool ez_io_file_exists(EzString path) {


### PR DESCRIPTION
Both `ezc/src/main.c::read_file` and stdlib `io.read_file` sized their buffer from `ftell` without checking the `-1` failure path; non-seekable inputs (pipes, FIFOs, `/dev/stdin`, `/proc`, sockets) wrap `(size_t)-1 + 1` to 0 and let `fread` write past the allocation. Falls back to a streaming read when `ftell` fails, keeping the seekable fast path unchanged.

Closes #1623, #1624.