### PR TITLE
chore(stdlib): remove duplicate fmt.eprint and fmt.eprintln

### DIFF
--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -4404,25 +4404,6 @@ static bool emit_fmt_call(CodeGen *cg, AstNode *node, const char *func) {
         return true;
     }
 
-    if (strcmp(func, "eprintln") == 0) {
-        if (node->data.call.arg_count == 0) {
-            emit(cg, "fputc('\\n', stderr)");
-        } else {
-            AstNode *arg = node->data.call.args[0];
-            emitf(cg, "ez_fmt_eprintln%s(", resolve_print_suffix(cg, arg));
-            emit_expression(cg, arg);
-            emit(cg, ")");
-        }
-        return true;
-    }
-
-    if (strcmp(func, "eprint") == 0 && node->data.call.arg_count > 0) {
-        emit(cg, "ez_fmt_eprint_str(");
-        emit_expression(cg, node->data.call.args[0]);
-        emit(cg, ")");
-        return true;
-    }
-
     if (strcmp(func, "format") == 0 && node->data.call.arg_count >= 1) {
         emit(cg, "ez_string_format(ez_default_arena, ");
         AstNode *fmt_arg = node->data.call.args[0];

--- a/ezc/src/stdlib/ez_fmt.c
+++ b/ezc/src/stdlib/ez_fmt.c
@@ -12,31 +12,6 @@
 #define EZ_FMT_INT_BUF      32
 #define EZ_FMT_FLOAT_BUF    64
 
-void ez_fmt_eprintln_str(EzString s) {
-    fwrite(s.data, 1, (size_t)s.len, stderr);
-    fputc('\n', stderr);
-}
-
-void ez_fmt_eprintln_int(int64_t v) {
-    fprintf(stderr, "%" PRId64 "\n", v);
-}
-
-void ez_fmt_eprintln_uint(uint64_t v) {
-    fprintf(stderr, "%" PRIu64 "\n", v);
-}
-
-void ez_fmt_eprintln_float(double v) {
-    fprintf(stderr, "%g\n", v);
-}
-
-void ez_fmt_eprintln_bool(bool v) {
-    fprintf(stderr, "%s\n", v ? "true" : "false");
-}
-
-void ez_fmt_eprint_str(EzString s) {
-    fwrite(s.data, 1, (size_t)s.len, stderr);
-}
-
 EzString ez_fmt_pad_left(EzArena *arena, EzString s, int64_t width, char ch) {
     if (s.len >= width) return s;
     int64_t pad = width - s.len;

--- a/ezc/src/stdlib/ez_fmt.h
+++ b/ezc/src/stdlib/ez_fmt.h
@@ -21,16 +21,6 @@
  * These helpers are for operations that need runtime support.
  */
 
-/* fmt.eprintln(value) — print to stderr with newline */
-void ez_fmt_eprintln_str(EzString s);
-void ez_fmt_eprintln_int(int64_t v);
-void ez_fmt_eprintln_uint(uint64_t v);
-void ez_fmt_eprintln_float(double v);
-void ez_fmt_eprintln_bool(bool v);
-
-/* fmt.eprint(value) — print to stderr without newline */
-void ez_fmt_eprint_str(EzString s);
-
 /* fmt.sprint(arena, values...) — concatenate values into a string */
 /* Handled by codegen via ez_string_format */
 

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -2730,8 +2730,7 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
                     strcmp(mfn, "float_fixed") == 0 ||
                     strcmp(mfn, "float_sci") == 0) {
                     result = &TYPE_STRING;
-                } else if (strcmp(mfn, "printf") == 0 || strcmp(mfn, "println") == 0 ||
-                           strcmp(mfn, "eprintln") == 0 || strcmp(mfn, "eprint") == 0) {
+                } else if (strcmp(mfn, "printf") == 0 || strcmp(mfn, "println") == 0) {
                     result = &TYPE_VOID;
                 } else {
                     emit_unknown_stdlib_fn(tc, mod, mfn, node);


### PR DESCRIPTION
## Summary
Removes the duplicate `fmt.eprintln()` and `fmt.eprint()` from the fmt module so the only path for stderr output is the builtin one. The builtin versions handle Error type, bigint, and composite prints; the fmt module copies were byte-for-byte identical C wrappers without that extra capability.

## Why this matters
@SchoolyB filed #1581 on 2026-04-28 noting the four-layer duplication: `ez_fmt_eprintln_*`/`ez_fmt_eprint_str` declarations in `ezc/src/stdlib/ez_fmt.h:24-39`, identical bodies in `ezc/src/stdlib/ez_fmt.c:15-37`, the fmt-module acceptance branch at `ezc/src/typechecker/typechecker.c:2734`, and the codegen cases in `emit_fmt_call()` at `ezc/src/codegen/codegen.c:4407-4425`. After removal the typechecker still recognizes `eprintln`/`eprint` as builtins via the unchanged builtins list at `typechecker.c:919`, and the builtin handlers at `codegen.c:2709-2750` still emit `ez_builtin_eprintln_*` for them.

## Testing
- `make build` succeeds clean
- `make test-unit` 158/158 PASS
- `eprintln("hello")` still compiles via the builtin path
- `fmt.eprintln("hello")` now reports the unknown stdlib function as expected

Fixes #1581
