### PR TITLE
tests(errors): add helpful hints to common error messages

### DIFF
--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -1269,24 +1269,27 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
              strcmp(op, "<") == 0 || strcmp(op, "<=") == 0 ||
              strcmp(op, ">") == 0 || strcmp(op, ">=") == 0) &&
             left->kind == TK_ARRAY && right->kind == TK_ARRAY) {
-            diag_error_code(tc->diag, "E3074",
-                NODE_FILE(tc, node), node->token.line, node->token.column, 0);
+            diag_error_code_help(tc->diag, "E3074",
+                NODE_FILE(tc, node), node->token.line, node->token.column, 0,
+                "use arrays.is_equal(a, b) to compare arrays element-by-element");
             infix_errored = true;
         }
         if ((strcmp(op, "==") == 0 || strcmp(op, "!=") == 0 ||
              strcmp(op, "<") == 0 || strcmp(op, "<=") == 0 ||
              strcmp(op, ">") == 0 || strcmp(op, ">=") == 0) &&
             left->kind == TK_MAP && right->kind == TK_MAP) {
-            diag_error_code(tc->diag, "E3076",
-                NODE_FILE(tc, node), node->token.line, node->token.column, 0);
+            diag_error_code_help(tc->diag, "E3076",
+                NODE_FILE(tc, node), node->token.line, node->token.column, 0,
+                "use maps.is_equal(a, b) to compare maps for equality");
             infix_errored = true;
         }
         if ((strcmp(op, "==") == 0 || strcmp(op, "!=") == 0 ||
              strcmp(op, "<") == 0 || strcmp(op, "<=") == 0 ||
              strcmp(op, ">") == 0 || strcmp(op, ">=") == 0) &&
             left->kind == TK_STRUCT && right->kind == TK_STRUCT) {
-            diag_error_code(tc->diag, "E3077",
-                NODE_FILE(tc, node), node->token.line, node->token.column, 0);
+            diag_error_code_help(tc->diag, "E3077",
+                NODE_FILE(tc, node), node->token.line, node->token.column, 0,
+                "compare individual fields instead, e.g. a.x == b.x");
             infix_errored = true;
         }
 
@@ -2664,8 +2667,9 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
                  * Assigning the intermediate result to a variable keeps
                  * each call site readable and avoids the AST-rewrite
                  * gymnastics that fluent-interface chaining would require. */
-                diag_error_code(tc->diag, "E3075",
-                    NODE_FILE(tc, fn), fn->token.line, fn->token.column, 0);
+                diag_error_code_help(tc->diag, "E3075",
+                    NODE_FILE(tc, fn), fn->token.line, fn->token.column, 0,
+                    "assign the intermediate result to a variable, then call the next struct function on it");
             }
             result = &TYPE_UNKNOWN;
             break;
@@ -5595,9 +5599,10 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
          * emits `ez_scope_restore(_, _scope_mark)` referencing a
          * variable that main never declares, and the C compile fails. */
         if (tc->current_func_is_main) {
-            diag_error_msg(tc->diag, "E3073",
+            diag_error_help(tc->diag, "E3073",
                 strdup("'return' is not allowed in main(); main exits when control reaches the closing brace"),
-                NODE_FILE(tc, node), node->token.line, node->token.column, 0);
+                NODE_FILE(tc, node), node->token.line, node->token.column, 0,
+                "use exit(code) to terminate with a status code");
             break;
         }
         /* #1521: reject addr() of local variable in return; the

--- a/ezc/src/util/error.c
+++ b/ezc/src/util/error.c
@@ -146,6 +146,12 @@ void diag_error_code(DiagnosticList *dl, const char *code,
         file, line, col_start, end_col, NULL);
 }
 
+void diag_error_code_help(DiagnosticList *dl, const char *code,
+    const char *file, int line, int col_start, int end_col, const char *help) {
+    diag_add(dl, SEV_ERROR, code, lookup_or_placeholder(code),
+        file, line, col_start, end_col, help);
+}
+
 void diag_warning_code(DiagnosticList *dl, const char *code,
     const char *file, int line, int col_start, int end_col) {
     diag_add(dl, SEV_WARNING, code, lookup_or_placeholder(code),

--- a/ezc/src/util/error.h
+++ b/ezc/src/util/error.h
@@ -80,6 +80,12 @@ void diag_warning_help(DiagnosticList *dl, const char *code, const char *message
 void diag_error_code(DiagnosticList *dl, const char *code,
     const char *file, int line, int col, int end_col);
 
+/* Same shape as diag_error_code, plus an actionable hint shown as `= help:`
+ * under the diagnostic. Use this when the registry message states the
+ * problem and the hint tells the user how to fix it. */
+void diag_error_code_help(DiagnosticList *dl, const char *code,
+    const char *file, int line, int col, int end_col, const char *help);
+
 void diag_error_codef(DiagnosticList *dl, const char *code,
     const char *file, int line, int col, int end_col, ...);
 


### PR DESCRIPTION
## Summary

Refs #1566.

Five common error codes now emit actionable `= help:` lines under the
diagnostic, matching the Rust-style format the issue describes:

| Code | Diagnosis | Hint |
| --- | --- | --- |
| E3074 | cannot compare arrays with `==` | use `arrays.is_equal(a, b)` to compare arrays element-by-element |
| E3076 | cannot compare maps with `==` | use `maps.is_equal(a, b)` to compare maps for equality |
| E3077 | cannot compare structs with `==` | compare individual fields instead, e.g. `a.x == b.x` |
| E3075 | chained struct function calls not supported | assign the intermediate result to a variable, then call the next struct function on it |
| E3073 | return not allowed in main | use `exit(code)` to terminate with a status code |

## Implementation

Adds a small new helper, `diag_error_code_help`, mirroring
`diag_error_code`'s signature plus a trailing `const char *help`. The
four `diag_error_code` call sites for E3074 / E3076 / E3077 / E3075
switch to it. E3073 was already on `diag_error_msg` and switches to the
existing `diag_error_help` (no API change).

| File | Change |
| --- | --- |
| `ezc/src/util/error.h` | Declares `diag_error_code_help`. |
| `ezc/src/util/error.c` | Implements `diag_error_code_help` (3 lines). |
| `ezc/src/typechecker/typechecker.c` | Updates the 5 call sites. |

## Verification

```
$ ez build /tmp/ez-array-cmp.ez
error[E3074]: arrays cannot be compared with comparison operators; ...
  --> /tmp/ez-array-cmp.ez:4:8
   |
 4 |   if a == b { }
   |        ^
   |
   = help: use arrays.is_equal(a, b) to compare arrays element-by-element
```

```
$ ez build /tmp/ez-return-main.ez
error[E3073]: 'return' is not allowed in main(); ...
  --> /tmp/ez-return-main.ez:2:3
   |
 2 |   return
   |   ^
   |
   = help: use exit(code) to terminate with a status code
```

`make test-unit` is green (158/158 pass) -- the existing assertions
only pin error codes (`has_code(d, "E3074")`), not message text, so
the additive help arg doesn't break anything. `make test` (full suite)
is also green.

## Out of scope (good follow-ups)

| Code | Why deferred |
| --- | --- |
| E3043 (cannot cast X to Y) | 7 `diag_error_msg` call sites; same swap pattern as E3073 but multiple mechanical touches. Easy follow-up PR. |
| E2039 (required param after optional) | Uses `diag_error_codef` (variadic registry template); needs a parallel `diag_error_codef_help` helper. Mechanical but a separate API surface. |

The new `diag_error_code_help` is the only API addition this PR makes;
keeping the diff scoped to the codef hint follow-up keeps the review
tight. Happy to take both follow-ups in a stacked PR if you'd prefer
all 7 errors landed together.

## Notes

- I deliberately did NOT touch the registry messages in
  `error_codes.h`. Some of them already include "; use ..." or
  "; assign ..." inline as semicolon-prefixed hints inside the main
  message. The `= help:` line now duplicates that, which is harmless
  but slightly noisy. A separate clean-up PR could trim the registry
  messages to just the diagnosis once the help-line pattern is
  established.
- The hint strings I picked match the wording in the issue's "Starter
  candidates" table verbatim where possible. Easy to adjust to your
  preferred phrasing.

