### PR TITLE
fix: runtime security bugs

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -231,4 +231,4 @@
 
 ---
 
-*Generated on 2026-05-12 14:33:09 UTC*
+*Generated on 2026-05-12 14:42:19 UTC*

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -3,7 +3,7 @@
 > Auto-generated from `ezc/src/util/error_codes.h`. Do not edit manually.
 > Run `./scripts/generate_errors.sh` to regenerate.
 
-**Total: 184 codes** (169 errors, 15 warnings)
+**Total: 187 codes** (172 errors, 15 warnings)
 
 ---
 
@@ -144,6 +144,9 @@
 | `E3083` | types | c_string() requires a raw C pointer; cannot convert a non-pointer type |
 | `E3084` | types | type_of() expects a value, not a type name; use type_of(instance) instead |
 | `E3085` | types | 'in' operator type mismatch: cannot check if '%s' is in '%s' |
+| `E3086` | types | fmt.%s format string must be a string literal; use string interpolation for dynamic values |
+| `E3087` | types | %%n is not permitted in fmt format strings |
+| `E3088` | types | fmt.%s format directive '%%%s' expects %s but argument %d has type '%s' |
 | `E4001` | names | this variable does not exist; check the spelling or make sure it is declared above this line |
 | `E4002` | names | this function does not exist; check the spelling or make sure it is defined |
 | `E4003` | names | variable '%s' already declared in this scope (line %d) |
@@ -228,4 +231,4 @@
 
 ---
 
-*Generated on 2026-05-12 14:24:26 UTC*
+*Generated on 2026-05-12 14:33:09 UTC*

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -3,7 +3,7 @@
 > Auto-generated from `ezc/src/util/error_codes.h`. Do not edit manually.
 > Run `./scripts/generate_errors.sh` to regenerate.
 
-**Total: 183 codes** (168 errors, 15 warnings)
+**Total: 184 codes** (169 errors, 15 warnings)
 
 ---
 
@@ -70,6 +70,7 @@
 | `E2076` | syntax | postfix operators ('++', '--', '^') cannot have whitespace before them; write 'x++', 'x--', or 'p^' with no space or newline |
 | `E2078` | syntax | variable declarations must start with 'const' or 'mut'; did you mean 'const %s' or 'mut %s'? |
 | `E2079` | syntax | 'nil' is a value, not a type; for a function that returns nothing, omit the '-> ...' clause |
+| `E2080` | syntax | invalid character in C header path; only [A-Za-z0-9./_+-] are permitted |
 | `E3001` | types | type mismatch; a value of one type is used where a different type is expected |
 | `E3002` | types | this operator does not work on this type; for example, strings cannot be subtracted |
 | `E3003` | types | invalid array index type; array indices must be integers |
@@ -227,4 +228,4 @@
 
 ---
 
-*Generated on 2026-05-04 16:42:32 UTC*
+*Generated on 2026-05-12 14:24:26 UTC*

--- a/cmd/ez/commands.go
+++ b/cmd/ez/commands.go
@@ -164,15 +164,12 @@ Examples:
   ez fmt file.ez        Format a single file
   ez fmt a.ez b.ez      Format multiple files
   ez fmt --check ./...  Exit non-zero if any file would change (CI gate)
-  ez fmt --diff file.ez Show the diff without modifying the file
 
-By default files are rewritten in place. Use --check for a non-mutating
-CI gate, or --diff to preview changes.`,
+By default files are rewritten in place. Use --check for a non-mutating CI gate.`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		check, _ := cmd.Flags().GetBool("check")
-		diff, _ := cmd.Flags().GetBool("diff")
-		exit := runFmt(args, check, diff)
+		exit := runFmt(args, check)
 		if exit != 0 {
 			os.Exit(exit)
 		}
@@ -540,7 +537,6 @@ Use "ez [command] --help" for more information about a command.
 	docCmd.Flags().StringP("output", "o", defaultDocOutputPath, "Path to write generated markdown")
 
 	fmtCmd.Flags().Bool("check", false, "Exit non-zero if any file would change; don't modify files")
-	fmtCmd.Flags().BoolP("diff", "d", false, "Show diff of changes without modifying files")
 
 	pzCmd.Flags().StringP("template", "t", "basic", "Template: basic, cli, lib, multi, server, client")
 	pzCmd.Flags().BoolP("comments", "c", false, "Include helpful syntax comments")

--- a/cmd/ez/commands.go
+++ b/cmd/ez/commands.go
@@ -152,6 +152,34 @@ to a different path (parent directories are created as needed).`,
 	},
 }
 
+var fmtCmd = &cobra.Command{
+	Use:   "fmt <path>",
+	Short: "Format .ez source files",
+	Long: `Normalize formatting of .ez source files (indentation, trailing
+whitespace, end-of-file newline, blank-line runs).
+
+Examples:
+  ez fmt .              Format .ez files in current directory (no recursion)
+  ez fmt ./...          Format recursively from current directory
+  ez fmt file.ez        Format a single file
+  ez fmt a.ez b.ez      Format multiple files
+  ez fmt --check ./...  Exit non-zero if any file would change (CI gate)
+  ez fmt --diff file.ez Show the diff without modifying the file
+
+By default files are rewritten in place. Use --check for a non-mutating
+CI gate, or --diff to preview changes.`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		check, _ := cmd.Flags().GetBool("check")
+		diff, _ := cmd.Flags().GetBool("diff")
+		exit := runFmt(args, check, diff)
+		if exit != 0 {
+			os.Exit(exit)
+		}
+		return nil
+	},
+}
+
 var reportCmd = &cobra.Command{
 	Use:   "report",
 	Short: "Print system info for bug reports",
@@ -462,7 +490,7 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
-	rootCmd.AddCommand(replCmd, updateCmd, installCmd, checkCmd, buildCmd, testCmd, reportCmd, versionCmd, docCmd, pzCmd, watchCmd)
+	rootCmd.AddCommand(replCmd, updateCmd, installCmd, checkCmd, buildCmd, testCmd, reportCmd, versionCmd, docCmd, fmtCmd, pzCmd, watchCmd)
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		CheckForUpdateAsync()
 	}
@@ -510,6 +538,9 @@ Use "ez [command] --help" for more information about a command.
 	watchCmd.Flags().StringP("quiet", "q", "", "Suppress warnings (use 'all' or comma-separated codes like W1001,W1002)")
 
 	docCmd.Flags().StringP("output", "o", defaultDocOutputPath, "Path to write generated markdown")
+
+	fmtCmd.Flags().Bool("check", false, "Exit non-zero if any file would change; don't modify files")
+	fmtCmd.Flags().BoolP("diff", "d", false, "Show diff of changes without modifying files")
 
 	pzCmd.Flags().StringP("template", "t", "basic", "Template: basic, cli, lib, multi, server, client")
 	pzCmd.Flags().BoolP("comments", "c", false, "Include helpful syntax comments")

--- a/cmd/ez/fmt.go
+++ b/cmd/ez/fmt.go
@@ -1,0 +1,254 @@
+package main
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// defaultFmtIndentSpaces is the width a leading tab is expanded to when
+// normalizing indentation in formatEZSource.
+const defaultFmtIndentSpaces = 4
+
+// formatEZSource applies the conservative formatting rules described in
+// issue #1564 and returns the rewritten source.
+//
+// Rules (deliberately limited to the issue's "Scope for initial
+// implementation" so the first version of `ez fmt` cannot accidentally
+// alter the meaning of legal .ez code):
+//
+//  1. Strip trailing whitespace from every line.
+//  2. Convert leading tabs in each line to defaultFmtIndentSpaces spaces
+//     (only inside the indent prefix; tabs inside string literals or
+//     after non-whitespace are left alone).
+//  3. Collapse three-or-more consecutive blank lines down to exactly two.
+//  4. Ensure the output ends with exactly one trailing newline.
+//
+// The function is byte-stable: feeding the output back through it
+// produces the same bytes, so `ez fmt --check` is a reliable CI gate.
+func formatEZSource(src []byte) []byte {
+	// Split preserving the trailing-newline situation; a trailing empty
+	// element after the final \n signals "file ended with a newline".
+	lines := strings.Split(string(src), "\n")
+	endsWithNewline := len(lines) > 0 && lines[len(lines)-1] == ""
+	if endsWithNewline {
+		lines = lines[:len(lines)-1]
+	}
+
+	for i, line := range lines {
+		// Rule 2: leading-tab indent normalization.
+		var indent strings.Builder
+		j := 0
+		for j < len(line) {
+			c := line[j]
+			if c == '\t' {
+				for k := 0; k < defaultFmtIndentSpaces; k++ {
+					indent.WriteByte(' ')
+				}
+				j++
+			} else if c == ' ' {
+				indent.WriteByte(' ')
+				j++
+			} else {
+				break
+			}
+		}
+		rest := line[j:]
+		// Rule 1: trim trailing whitespace.
+		rest = strings.TrimRight(rest, " \t")
+		// An all-whitespace line collapses to "" so blank-line detection
+		// in rule 3 catches it.
+		if rest == "" {
+			lines[i] = ""
+		} else {
+			lines[i] = indent.String() + rest
+		}
+	}
+
+	// Rule 3: collapse 3+ consecutive blank lines to exactly 2.
+	var out []string
+	blank := 0
+	for _, line := range lines {
+		if line == "" {
+			blank++
+			if blank <= 2 {
+				out = append(out, line)
+			}
+		} else {
+			blank = 0
+			out = append(out, line)
+		}
+	}
+
+	// Rule 4: trim trailing blank lines, then append exactly one newline.
+	for len(out) > 0 && out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+	return []byte(strings.Join(out, "\n") + "\n")
+}
+
+// unifiedDiff renders a minimal three-context unified diff for two byte
+// slices. We avoid pulling in a diff library so `ez fmt --diff` doesn't
+// add a new transitive dependency.
+//
+// The output is line-based; for the small per-file diffs an in-place
+// formatter produces, the simple hunk model below is sufficient.
+func unifiedDiff(path string, a, b []byte) string {
+	if bytes.Equal(a, b) {
+		return ""
+	}
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "--- a/%s\n", path)
+	fmt.Fprintf(&buf, "+++ b/%s\n", path)
+	la := strings.Split(string(a), "\n")
+	lb := strings.Split(string(b), "\n")
+	// Render the longer side, prefixing each line with - and + as
+	// appropriate. The output is intentionally simple: it shows every
+	// line, marked by which side it came from. For a 200-line file the
+	// noise is acceptable; a richer diff is a v2 follow-up.
+	n := len(la)
+	if len(lb) > n {
+		n = len(lb)
+	}
+	for i := 0; i < n; i++ {
+		var av, bv string
+		var aHas, bHas bool
+		if i < len(la) {
+			av = la[i]
+			aHas = true
+		}
+		if i < len(lb) {
+			bv = lb[i]
+			bHas = true
+		}
+		switch {
+		case aHas && bHas && av == bv:
+			fmt.Fprintf(&buf, " %s\n", av)
+		case aHas && bHas:
+			fmt.Fprintf(&buf, "-%s\n", av)
+			fmt.Fprintf(&buf, "+%s\n", bv)
+		case aHas:
+			fmt.Fprintf(&buf, "-%s\n", av)
+		case bHas:
+			fmt.Fprintf(&buf, "+%s\n", bv)
+		}
+	}
+	return buf.String()
+}
+
+// collectFmtFiles expands the user-supplied args into a deduplicated list
+// of .ez file paths, mirroring the arg shape used by `ez doc`:
+//
+//   - "./..." or "<dir>/..." -> recursive walk for .ez files
+//   - "foo.ez"               -> single file
+//   - "<dir>"                -> non-recursive directory scan
+//
+// Errors on individual entries are printed to stderr and the bad entry
+// is skipped; the function never aborts the whole run on a single
+// missing arg, matching how `generateDocs` in doc.go behaves.
+func collectFmtFiles(args []string) []string {
+	seen := make(map[string]struct{})
+	var files []string
+	add := func(p string) {
+		ap, err := filepath.Abs(p)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ez fmt: cannot resolve %s: %v\n", p, err)
+			return
+		}
+		if _, ok := seen[ap]; ok {
+			return
+		}
+		seen[ap] = struct{}{}
+		files = append(files, ap)
+	}
+
+	for _, arg := range args {
+		switch {
+		case strings.HasSuffix(arg, "/..."):
+			baseDir := strings.TrimSuffix(arg, "/...")
+			if baseDir == "" || baseDir == "." {
+				baseDir = "."
+			}
+			filepath.Walk(baseDir, func(p string, info os.FileInfo, err error) error {
+				if err != nil {
+					return nil
+				}
+				if !info.IsDir() && strings.HasSuffix(p, ".ez") {
+					add(p)
+				}
+				return nil
+			})
+		case strings.HasSuffix(arg, ".ez"):
+			add(arg)
+		default:
+			entries, err := os.ReadDir(arg)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "ez fmt: %v\n", err)
+				continue
+			}
+			for _, e := range entries {
+				if !e.IsDir() && strings.HasSuffix(e.Name(), ".ez") {
+					add(filepath.Join(arg, e.Name()))
+				}
+			}
+		}
+	}
+	return files
+}
+
+// runFmt is the entry point invoked by the Cobra fmtCmd. It returns the
+// exit code the caller should propagate (0 success, 1 if --check found
+// unformatted files, 2 on file I/O error).
+//
+// The three modes are mutually exclusive in spirit but the function
+// handles them in order so a caller passing both --check and --diff
+// still gets sensible behavior (diffs printed; non-zero exit if any
+// file would change).
+func runFmt(args []string, checkMode, diffMode bool) int {
+	files := collectFmtFiles(args)
+	if len(files) == 0 {
+		fmt.Println("ez fmt: no .ez files found")
+		return 0
+	}
+
+	exit := 0
+	for _, path := range files {
+		src, err := os.ReadFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ez fmt: %v\n", err)
+			exit = 2
+			continue
+		}
+		out := formatEZSource(src)
+		if bytes.Equal(src, out) {
+			continue
+		}
+		if diffMode {
+			fmt.Print(unifiedDiff(path, src, out))
+		}
+		if checkMode {
+			fmt.Printf("would format: %s\n", path)
+			if exit == 0 {
+				exit = 1
+			}
+			continue
+		}
+		if diffMode && !checkMode {
+			// --diff alone is a preview that doesn't touch disk; the
+			// user gets the proposed changes but the file stays put.
+			continue
+		}
+		if err := os.WriteFile(path, out, 0644); err != nil {
+			fmt.Fprintf(os.Stderr, "ez fmt: writing %s: %v\n", path, err)
+			exit = 2
+			continue
+		}
+		fmt.Printf("formatted: %s\n", path)
+	}
+	return exit
+}

--- a/cmd/ez/fmt.go
+++ b/cmd/ez/fmt.go
@@ -92,55 +92,6 @@ func formatEZSource(src []byte) []byte {
 	return []byte(strings.Join(out, "\n") + "\n")
 }
 
-// unifiedDiff renders a minimal three-context unified diff for two byte
-// slices. We avoid pulling in a diff library so `ez fmt --diff` doesn't
-// add a new transitive dependency.
-//
-// The output is line-based; for the small per-file diffs an in-place
-// formatter produces, the simple hunk model below is sufficient.
-func unifiedDiff(path string, a, b []byte) string {
-	if bytes.Equal(a, b) {
-		return ""
-	}
-	var buf strings.Builder
-	fmt.Fprintf(&buf, "--- a/%s\n", path)
-	fmt.Fprintf(&buf, "+++ b/%s\n", path)
-	la := strings.Split(string(a), "\n")
-	lb := strings.Split(string(b), "\n")
-	// Render the longer side, prefixing each line with - and + as
-	// appropriate. The output is intentionally simple: it shows every
-	// line, marked by which side it came from. For a 200-line file the
-	// noise is acceptable; a richer diff is a v2 follow-up.
-	n := len(la)
-	if len(lb) > n {
-		n = len(lb)
-	}
-	for i := 0; i < n; i++ {
-		var av, bv string
-		var aHas, bHas bool
-		if i < len(la) {
-			av = la[i]
-			aHas = true
-		}
-		if i < len(lb) {
-			bv = lb[i]
-			bHas = true
-		}
-		switch {
-		case aHas && bHas && av == bv:
-			fmt.Fprintf(&buf, " %s\n", av)
-		case aHas && bHas:
-			fmt.Fprintf(&buf, "-%s\n", av)
-			fmt.Fprintf(&buf, "+%s\n", bv)
-		case aHas:
-			fmt.Fprintf(&buf, "-%s\n", av)
-		case bHas:
-			fmt.Fprintf(&buf, "+%s\n", bv)
-		}
-	}
-	return buf.String()
-}
-
 // collectFmtFiles expands the user-supplied args into a deduplicated list
 // of .ez file paths, mirroring the arg shape used by `ez doc`:
 //
@@ -204,12 +155,7 @@ func collectFmtFiles(args []string) []string {
 // runFmt is the entry point invoked by the Cobra fmtCmd. It returns the
 // exit code the caller should propagate (0 success, 1 if --check found
 // unformatted files, 2 on file I/O error).
-//
-// The three modes are mutually exclusive in spirit but the function
-// handles them in order so a caller passing both --check and --diff
-// still gets sensible behavior (diffs printed; non-zero exit if any
-// file would change).
-func runFmt(args []string, checkMode, diffMode bool) int {
+func runFmt(args []string, checkMode bool) int {
 	files := collectFmtFiles(args)
 	if len(files) == 0 {
 		fmt.Println("ez fmt: no .ez files found")
@@ -228,19 +174,11 @@ func runFmt(args []string, checkMode, diffMode bool) int {
 		if bytes.Equal(src, out) {
 			continue
 		}
-		if diffMode {
-			fmt.Print(unifiedDiff(path, src, out))
-		}
 		if checkMode {
 			fmt.Printf("would format: %s\n", path)
 			if exit == 0 {
 				exit = 1
 			}
-			continue
-		}
-		if diffMode && !checkMode {
-			// --diff alone is a preview that doesn't touch disk; the
-			// user gets the proposed changes but the file stays put.
 			continue
 		}
 		if err := os.WriteFile(path, out, 0644); err != nil {

--- a/cmd/ez/fmt_test.go
+++ b/cmd/ez/fmt_test.go
@@ -4,7 +4,6 @@ package main
 // Licensed under the MIT License. See LICENSE for details.
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -72,22 +71,5 @@ func TestFormatEZSourceMixedTabsAndSpaces(t *testing.T) {
 	got := string(formatEZSource([]byte(in)))
 	if got != want {
 		t.Fatalf("mixed tab+space indent not normalized\ngot:  %q\nwant: %q", got, want)
-	}
-}
-
-func TestUnifiedDiffIdentical(t *testing.T) {
-	d := unifiedDiff("a.ez", []byte("x\n"), []byte("x\n"))
-	if d != "" {
-		t.Fatalf("expected empty diff for identical inputs, got %q", d)
-	}
-}
-
-func TestUnifiedDiffShowsBothSides(t *testing.T) {
-	d := unifiedDiff("file.ez", []byte("a\nb\n"), []byte("a\nB\n"))
-	if !strings.Contains(d, "-b") || !strings.Contains(d, "+B") {
-		t.Fatalf("diff missing change markers: %q", d)
-	}
-	if !strings.Contains(d, "file.ez") {
-		t.Fatalf("diff missing path header: %q", d)
 	}
 }

--- a/cmd/ez/fmt_test.go
+++ b/cmd/ez/fmt_test.go
@@ -1,0 +1,93 @@
+package main
+
+// Copyright (c) 2025-Present Marshall A Burns
+// Licensed under the MIT License. See LICENSE for details.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFormatEZSourceTrailingWhitespace(t *testing.T) {
+	in := "do main() {  \n    println(\"hi\")\t \n}\n"
+	want := "do main() {\n    println(\"hi\")\n}\n"
+	got := string(formatEZSource([]byte(in)))
+	if got != want {
+		t.Fatalf("trailing whitespace not trimmed\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestFormatEZSourceTabsToSpaces(t *testing.T) {
+	in := "do main() {\n\tprintln(\"hi\")\n\t\treturn 0\n}\n"
+	want := "do main() {\n    println(\"hi\")\n        return 0\n}\n"
+	got := string(formatEZSource([]byte(in)))
+	if got != want {
+		t.Fatalf("leading tabs not expanded to 4 spaces\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestFormatEZSourceCollapseBlankLines(t *testing.T) {
+	in := "do main() {\n    println(\"a\")\n\n\n\n\n    println(\"b\")\n}\n"
+	want := "do main() {\n    println(\"a\")\n\n\n    println(\"b\")\n}\n"
+	got := string(formatEZSource([]byte(in)))
+	if got != want {
+		t.Fatalf("blank-line run not collapsed to 2\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestFormatEZSourceEnsuresFinalNewline(t *testing.T) {
+	for _, in := range []string{
+		"println(\"hi\")",
+		"println(\"hi\")\n",
+		"println(\"hi\")\n\n\n",
+	} {
+		want := "println(\"hi\")\n"
+		got := string(formatEZSource([]byte(in)))
+		if got != want {
+			t.Fatalf("EOF not normalized for %q\ngot:  %q\nwant: %q", in, got, want)
+		}
+	}
+}
+
+func TestFormatEZSourceIdempotent(t *testing.T) {
+	in := []byte("do main() {\n\tif x {\n\t\tprintln(\"a\")  \n\n\n\n\t}\n}\n")
+	once := formatEZSource(in)
+	twice := formatEZSource(once)
+	if string(once) != string(twice) {
+		t.Fatalf("format is not idempotent\nonce:  %q\ntwice: %q", once, twice)
+	}
+}
+
+func TestFormatEZSourceCleanInputUnchanged(t *testing.T) {
+	in := "do main() {\n    println(\"hi\")\n}\n"
+	got := string(formatEZSource([]byte(in)))
+	if got != in {
+		t.Fatalf("clean input rewritten\ngot:  %q\nwant: %q", got, in)
+	}
+}
+
+func TestFormatEZSourceMixedTabsAndSpaces(t *testing.T) {
+	in := "if x {\n\t    println(\"mixed\")\n}\n"
+	want := "if x {\n        println(\"mixed\")\n}\n"
+	got := string(formatEZSource([]byte(in)))
+	if got != want {
+		t.Fatalf("mixed tab+space indent not normalized\ngot:  %q\nwant: %q", got, want)
+	}
+}
+
+func TestUnifiedDiffIdentical(t *testing.T) {
+	d := unifiedDiff("a.ez", []byte("x\n"), []byte("x\n"))
+	if d != "" {
+		t.Fatalf("expected empty diff for identical inputs, got %q", d)
+	}
+}
+
+func TestUnifiedDiffShowsBothSides(t *testing.T) {
+	d := unifiedDiff("file.ez", []byte("a\nb\n"), []byte("a\nB\n"))
+	if !strings.Contains(d, "-b") || !strings.Contains(d, "+B") {
+		t.Fatalf("diff missing change markers: %q", d)
+	}
+	if !strings.Contains(d, "file.ez") {
+		t.Fatalf("diff missing path header: %q", d)
+	}
+}

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -7423,6 +7423,16 @@ void codegen_generate(CodeGen *cg, AstNode *program) {
         emit(cg, "\n/* C interop headers */\n");
         for (int i = 0; i < cg->c_header_count; i++) {
             const char *hdr = cg->c_headers[i];
+            /* Defense-in-depth: skip any path that slipped through with dangerous chars */
+            bool safe = true;
+            for (const char *q = hdr; *q; q++) {
+                unsigned char c = (unsigned char)*q;
+                bool ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                          (c >= '0' && c <= '9') ||
+                          c == '/' || c == '.' || c == '_' || c == '-' || c == '+';
+                if (!ok) { safe = false; break; }
+            }
+            if (!safe) continue;
             if (strncmp(hdr, "./", 2) == 0 || strncmp(hdr, "../", 3) == 0) {
                 emitf(cg, "#include \"%s\"\n", hdr);
             } else {

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -2275,6 +2275,57 @@ static void emit_to_string(CodeGen *cg, AstNode *arg) {
     emit(cg, ")");
 }
 
+/* Emit a fmt format string literal with %d/%i/%u upgraded to %lld/%llu for
+ * EZ int/uint arguments (which are int64_t/uint64_t) to avoid -Wformat. */
+static void emit_fmt_string_normalized(CodeGen *cg, const char *fmt_str, AstNode *call_node) {
+    const char *p = fmt_str;
+    int di = 1; /* which call arg corresponds to the next directive */
+    buf_append_char(&cg->output, '"');
+    while (*p) {
+        if (*p != '%') { buf_append_char(&cg->output, *p++); continue; }
+        /* Emit '%' and start scanning the directive */
+        buf_append_char(&cg->output, '%');
+        p++;
+        if (!*p) break;
+        if (*p == '%') { buf_append_char(&cg->output, '%'); p++; continue; }
+        /* Emit flags verbatim */
+        while (*p == '-' || *p == '+' || *p == ' ' || *p == '0' || *p == '#')
+            buf_append_char(&cg->output, *p++);
+        /* Emit width verbatim */
+        while (*p >= '0' && *p <= '9') buf_append_char(&cg->output, *p++);
+        /* Emit precision verbatim */
+        if (*p == '.') {
+            buf_append_char(&cg->output, *p++);
+            while (*p >= '0' && *p <= '9') buf_append_char(&cg->output, *p++);
+        }
+        /* Check for existing length modifier */
+        bool has_length = (*p == 'h' || *p == 'l' || *p == 'L');
+        if (has_length) {
+            buf_append_char(&cg->output, *p++);
+            if ((*(p-1) == 'h' && *p == 'h') || (*(p-1) == 'l' && *p == 'l'))
+                buf_append_char(&cg->output, *p++);
+        }
+        char spec = *p ? *p++ : 0;
+        if (!spec) break;
+        /* Upgrade bare %d/%i/%u to %lld/%llu when arg is EZ int/uint */
+        if (!has_length && (spec == 'd' || spec == 'i' || spec == 'u') &&
+            di < call_node->data.call.arg_count) {
+            EzType *dt = cg->type_table ?
+                typetable_get(cg->type_table, call_node->data.call.args[di]) : NULL;
+            if (dt && (spec == 'd' || spec == 'i') && dt->kind == TK_INT) {
+                buf_append_char(&cg->output, 'l');
+                buf_append_char(&cg->output, 'l');
+            } else if (dt && spec == 'u' && dt->kind == TK_UINT) {
+                buf_append_char(&cg->output, 'l');
+                buf_append_char(&cg->output, 'l');
+            }
+        }
+        buf_append_char(&cg->output, spec);
+        di++;
+    }
+    buf_append_char(&cg->output, '"');
+}
+
 static void emit_fmt_args(CodeGen *cg, AstNode *node, int start_idx) {
     for (int i = start_idx; i < node->data.call.arg_count; i++) {
         emit(cg, ", ");
@@ -4408,12 +4459,9 @@ static bool emit_fmt_call(CodeGen *cg, AstNode *node, const char *func) {
     if (strcmp(func, "printf") == 0 && node->data.call.arg_count >= 1) {
         emit(cg, "printf(");
         AstNode *fmt_arg = node->data.call.args[0];
-        if (fmt_arg->kind == NODE_STRING_VALUE) {
-            emitf(cg, "\"%s\"", fmt_arg->data.string_value.value);
-        } else {
-            emit_expression(cg, fmt_arg);
-            emit(cg, ".data");
-        }
+        if (fmt_arg->kind == NODE_STRING_VALUE)
+            emit_fmt_string_normalized(cg, fmt_arg->data.string_value.value, node);
+        else { emit_expression(cg, fmt_arg); emit(cg, ".data"); }
         emit_fmt_args(cg, node, 1);
         emit(cg, ")");
         return true;
@@ -4422,12 +4470,9 @@ static bool emit_fmt_call(CodeGen *cg, AstNode *node, const char *func) {
     if (strcmp(func, "sprintf") == 0 && node->data.call.arg_count >= 1) {
         emit(cg, "ez_string_format(ez_default_arena, ");
         AstNode *fmt_arg = node->data.call.args[0];
-        if (fmt_arg->kind == NODE_STRING_VALUE) {
-            emitf(cg, "\"%s\"", fmt_arg->data.string_value.value);
-        } else {
-            emit_expression(cg, fmt_arg);
-            emit(cg, ".data");
-        }
+        if (fmt_arg->kind == NODE_STRING_VALUE)
+            emit_fmt_string_normalized(cg, fmt_arg->data.string_value.value, node);
+        else { emit_expression(cg, fmt_arg); emit(cg, ".data"); }
         emit_fmt_args(cg, node, 1);
         emit(cg, ")");
         return true;
@@ -4436,12 +4481,9 @@ static bool emit_fmt_call(CodeGen *cg, AstNode *node, const char *func) {
     if (strcmp(func, "format") == 0 && node->data.call.arg_count >= 1) {
         emit(cg, "ez_string_format(ez_default_arena, ");
         AstNode *fmt_arg = node->data.call.args[0];
-        if (fmt_arg->kind == NODE_STRING_VALUE) {
-            emitf(cg, "\"%s\"", fmt_arg->data.string_value.value);
-        } else {
-            emit_expression(cg, fmt_arg);
-            emit(cg, ".data");
-        }
+        if (fmt_arg->kind == NODE_STRING_VALUE)
+            emit_fmt_string_normalized(cg, fmt_arg->data.string_value.value, node);
+        else { emit_expression(cg, fmt_arg); emit(cg, ".data"); }
         emit_fmt_args(cg, node, 1);
         emit(cg, ")");
         return true;

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -4043,13 +4043,27 @@ static bool emit_arrays_call(CodeGen *cg, AstNode *node, const char *func) {
         return true;
     }
     if (strcmp(func, "sort_asc") == 0 && node->data.call.arg_count == 1) {
-        emit(cg, "ez_arrays_sort_asc(");
+        EzType *sa_t = cg->type_table ? typetable_get(cg->type_table, node->data.call.args[0]) : NULL;
+        const char *sa_elem = (sa_t && sa_t->kind == TK_ARRAY) ? sa_t->element_type : NULL;
+        if (sa_elem && strcmp(sa_elem, "float") == 0)
+            emit(cg, "ez_arrays_sort_asc_float(");
+        else if (sa_elem && strcmp(sa_elem, "string") == 0)
+            emit(cg, "ez_arrays_sort_asc_str(");
+        else
+            emit(cg, "ez_arrays_sort_asc(");
         emit_array_arg_addr(cg, node->data.call.args[0]);
         emit(cg, ")");
         return true;
     }
     if (strcmp(func, "sort_desc") == 0 && node->data.call.arg_count == 1) {
-        emit(cg, "ez_arrays_sort_desc(");
+        EzType *sd_t = cg->type_table ? typetable_get(cg->type_table, node->data.call.args[0]) : NULL;
+        const char *sd_elem = (sd_t && sd_t->kind == TK_ARRAY) ? sd_t->element_type : NULL;
+        if (sd_elem && strcmp(sd_elem, "float") == 0)
+            emit(cg, "ez_arrays_sort_desc_float(");
+        else if (sd_elem && strcmp(sd_elem, "string") == 0)
+            emit(cg, "ez_arrays_sort_desc_str(");
+        else
+            emit(cg, "ez_arrays_sort_desc(");
         emit_array_arg_addr(cg, node->data.call.args[0]);
         emit(cg, ")");
         return true;

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -782,17 +782,17 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
             }
         } else {
             while (*s) {
-                if (s[0] == '\\' && s[1] == 'x' && isxdigit(s[2])) {
+                if (s[0] == '\\' && s[1] == 'x' && isxdigit((unsigned char)s[2])) {
                     /* Emit \xNN then break the string if followed by a hex digit */
                     buf_append_char(&cg->output, s[0]); /* \ */
                     buf_append_char(&cg->output, s[1]); /* x */
                     buf_append_char(&cg->output, s[2]); /* first hex */
                     s += 3;
-                    if (isxdigit(*s)) {
+                    if (isxdigit((unsigned char)*s)) {
                         buf_append_char(&cg->output, *s); /* second hex */
                         s++;
                     }
-                    if (isxdigit(*s)) {
+                    if (isxdigit((unsigned char)*s)) {
                         /* Next char is also hex; break the string */
                         emit(cg, "\" \"");
                     }

--- a/ezc/src/lexer/lexer.c
+++ b/ezc/src/lexer/lexer.c
@@ -79,7 +79,7 @@ static void skip_whitespace_and_comments(Lexer *l) {
 
 static const char *read_identifier(Lexer *l) {
     int start = l->position;
-    while (isalpha(l->ch) || l->ch == '_' || isdigit(l->ch)) {
+    while (isalpha((unsigned char)l->ch) || l->ch == '_' || isdigit((unsigned char)l->ch)) {
         read_char(l);
     }
     return arena_strndup(l->arena, l->input + start, l->position - start);
@@ -95,7 +95,7 @@ static const char *read_number(Lexer *l, TokenType *type) {
         if (next == 'x' || next == 'X') {
             read_char(l); read_char(l);
             int dstart = l->position;
-            while (isxdigit(l->ch) || l->ch == '_') read_char(l);
+            while (isxdigit((unsigned char)l->ch) || l->ch == '_') read_char(l);
             if (l->position == dstart) {
                 l->error_code = "E1010";
                 l->error_msg = "invalid number format: '0x' must be followed by hex digits (0-9, a-f)";
@@ -124,19 +124,19 @@ static const char *read_number(Lexer *l, TokenType *type) {
         }
     }
 
-    while (isdigit(l->ch) || l->ch == '_') {
+    while (isdigit((unsigned char)l->ch) || l->ch == '_') {
         read_char(l);
     }
 
     if (l->ch == '.') {
         char next = peek_char(l);
-        if (isdigit(next) || next == '_' || next == 0 || next == '\n' ||
+        if (isdigit((unsigned char)next) || next == '_' || next == 0 || next == '\n' ||
             next == ' ' || next == ')' || next == '}' || next == ',' ||
             next == ';') {
             /* Consume decimal point; validation below will catch errors */
             *type = TOK_FLOAT;
             read_char(l);
-            while (isdigit(l->ch) || l->ch == '_') {
+            while (isdigit((unsigned char)l->ch) || l->ch == '_') {
                 read_char(l);
             }
         }
@@ -164,7 +164,7 @@ static const char *read_number(Lexer *l, TokenType *type) {
                     if (i > 0 && s[i-1] == '_') { l->error_code = "E1014"; l->error_msg = "underscore cannot appear before decimal point"; }
                     if (s[i+1] == '_') { l->error_code = "E1015"; l->error_msg = "underscore cannot appear after decimal point"; }
                     /* E1016: trailing decimal */
-                    if (!s[i+1] || (!isdigit(s[i+1]) && s[i+1] != '_')) { l->error_code = "E1016"; l->error_msg = "number cannot end with decimal point"; }
+                    if (!s[i+1] || (!isdigit((unsigned char)s[i+1]) && s[i+1] != '_')) { l->error_code = "E1016"; l->error_msg = "number cannot end with decimal point"; }
                     break;
                 }
             }
@@ -186,13 +186,13 @@ static const char *read_string(Lexer *l) {
             if (l->ch == 'x') {
                 /* Hex escape: \xNN; exactly two hex digits */
                 read_char(l);
-                if (!isxdigit(l->ch)) {
+                if (!isxdigit((unsigned char)l->ch)) {
                     l->error_code = "E1006";
                     l->error_msg = "invalid hex escape sequence; \\x must be followed by exactly two hex digits";
                     continue;
                 }
                 read_char(l);
-                if (!isxdigit(l->ch)) {
+                if (!isxdigit((unsigned char)l->ch)) {
                     l->error_code = "E1006";
                     l->error_msg = "invalid hex escape sequence; \\x must be followed by exactly two hex digits";
                     continue;
@@ -391,7 +391,7 @@ Token lexer_next_token(Lexer *l) {
         } else if (peek_char(l) == 'i' && l->read_position + 1 < l->input_len &&
                    l->input[l->read_position + 1] == 'n' &&
                    (l->read_position + 2 >= l->input_len ||
-                    !isalpha(l->input[l->read_position + 2]))) {
+                    !isalpha((unsigned char)l->input[l->read_position + 2]))) {
             /* !in → NOT_IN */
             read_char(l); /* skip i */
             read_char(l); /* skip n */
@@ -536,11 +536,11 @@ Token lexer_next_token(Lexer *l) {
         goto done;
 
     default:
-        if (isalpha(l->ch) || l->ch == '_') {
+        if (isalpha((unsigned char)l->ch) || l->ch == '_') {
             tok.literal = read_identifier(l);
             tok.type = token_lookup_ident(tok.literal);
             goto done;
-        } else if (isdigit(l->ch)) {
+        } else if (isdigit((unsigned char)l->ch)) {
             TokenType num_type;
             tok.literal = read_number(l, &num_type);
             if (l->error_code) {

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -1725,6 +1725,19 @@ static AstNode *parse_import_statement(Parser *p) {
             item->path = p->cur_token.literal;
             item->alias = "c";
             item->module = "c";
+            /* Validate path: only [A-Za-z0-9./_+-] permitted to prevent injection */
+            for (const char *q = item->path; *q; q++) {
+                unsigned char c = (unsigned char)*q;
+                bool ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+                          (c >= '0' && c <= '9') ||
+                          c == '/' || c == '.' || c == '_' || c == '-' || c == '+';
+                if (!ok) {
+                    diag_error(p->diag, "E2080",
+                        arena_strdup(p->arena, "invalid character in C header path; only [A-Za-z0-9./_+-] are permitted"),
+                        p->file, p->cur_token.line, p->cur_token.column, 0);
+                    break;
+                }
+            }
             goto import_item_done;
         }
 

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -640,7 +640,7 @@ static AstNode *parse_string_literal(Parser *p) {
         for (int i = 0; raw[i]; i++) {
             if (raw[i] == '\\') { i++; continue; }
             if (raw[i] == '$' && raw[i + 1] != '{' && raw[i + 1] != '\0' &&
-                (isalpha(raw[i + 1]) || raw[i + 1] == '_')) {
+                (isalpha((unsigned char)raw[i + 1]) || raw[i + 1] == '_')) {
                 diag_error_code(p->diag, "E2057", p->file, p->cur_token.line, p->cur_token.column, 0);
                 break;
             }

--- a/ezc/src/stdlib/ez_arrays.c
+++ b/ezc/src/stdlib/ez_arrays.c
@@ -343,6 +343,31 @@ static int cmp_i64_desc(const void *a, const void *b) {
     return (vb > va) - (vb < va);
 }
 
+static int cmp_f64_asc(const void *a, const void *b) {
+    double va = *(const double *)a;
+    double vb = *(const double *)b;
+    return (va > vb) - (va < vb);
+}
+
+static int cmp_f64_desc(const void *a, const void *b) {
+    double va = *(const double *)a;
+    double vb = *(const double *)b;
+    return (vb > va) - (vb < va);
+}
+
+static int cmp_str_asc(const void *a, const void *b) {
+    const EzString *sa = (const EzString *)a;
+    const EzString *sb = (const EzString *)b;
+    int32_t min_len = sa->len < sb->len ? sa->len : sb->len;
+    int cmp = memcmp(sa->data, sb->data, (size_t)min_len);
+    if (cmp != 0) return cmp;
+    return (sa->len > sb->len) - (sa->len < sb->len);
+}
+
+static int cmp_str_desc(const void *a, const void *b) {
+    return cmp_str_asc(b, a);
+}
+
 void ez_arrays_sort_asc(EzArray *arr) {
     if (arr->iterating > 0)
         ez_panic(__FILE__, __LINE__, "cannot modify array during for_each iteration");
@@ -350,9 +375,37 @@ void ez_arrays_sort_asc(EzArray *arr) {
     qsort(arr->data, (size_t)arr->len, (size_t)arr->elem_size, cmp_i64_asc);
 }
 
+void ez_arrays_sort_asc_float(EzArray *arr) {
+    if (arr->iterating > 0)
+        ez_panic(__FILE__, __LINE__, "cannot modify array during for_each iteration");
+    if (arr->len <= 1) return;
+    qsort(arr->data, (size_t)arr->len, (size_t)arr->elem_size, cmp_f64_asc);
+}
+
+void ez_arrays_sort_asc_str(EzArray *arr) {
+    if (arr->iterating > 0)
+        ez_panic(__FILE__, __LINE__, "cannot modify array during for_each iteration");
+    if (arr->len <= 1) return;
+    qsort(arr->data, (size_t)arr->len, (size_t)arr->elem_size, cmp_str_asc);
+}
+
 void ez_arrays_sort_desc(EzArray *arr) {
     if (arr->iterating > 0)
         ez_panic(__FILE__, __LINE__, "cannot modify array during for_each iteration");
     if (arr->len <= 1) return;
     qsort(arr->data, (size_t)arr->len, (size_t)arr->elem_size, cmp_i64_desc);
+}
+
+void ez_arrays_sort_desc_float(EzArray *arr) {
+    if (arr->iterating > 0)
+        ez_panic(__FILE__, __LINE__, "cannot modify array during for_each iteration");
+    if (arr->len <= 1) return;
+    qsort(arr->data, (size_t)arr->len, (size_t)arr->elem_size, cmp_f64_desc);
+}
+
+void ez_arrays_sort_desc_str(EzArray *arr) {
+    if (arr->iterating > 0)
+        ez_panic(__FILE__, __LINE__, "cannot modify array during for_each iteration");
+    if (arr->len <= 1) return;
+    qsort(arr->data, (size_t)arr->len, (size_t)arr->elem_size, cmp_str_desc);
 }

--- a/ezc/src/stdlib/ez_arrays.h
+++ b/ezc/src/stdlib/ez_arrays.h
@@ -55,6 +55,10 @@ int64_t ez_arrays_get_max(EzArray *arr);
 
 /* Sort */
 void ez_arrays_sort_asc(EzArray *arr);
+void ez_arrays_sort_asc_float(EzArray *arr);
+void ez_arrays_sort_asc_str(EzArray *arr);
 void ez_arrays_sort_desc(EzArray *arr);
+void ez_arrays_sort_desc_float(EzArray *arr);
+void ez_arrays_sort_desc_str(EzArray *arr);
 
 #endif

--- a/ezc/src/stdlib/ez_csv.c
+++ b/ezc/src/stdlib/ez_csv.c
@@ -74,9 +74,19 @@ EzString ez_csv_stringify(EzArena *arena, EzArray *data) {
         return (EzString){ buf, pos };
     }
 
-    /* Fallback: array of arrays (original behavior) */
-    int32_t est = data->len * 64;
-    char *buf = ez_arena_alloc(arena, (size_t)est);
+    /* Fallback: array of arrays ([[string]] rows).
+     * First pass: compute exact required size to avoid heap overflow. */
+    int32_t total = 0;
+    for (int32_t i = 0; i < data->len; i++) {
+        EzArray *row = (EzArray *)((char *)data->data + (size_t)i * sizeof(EzArray));
+        for (int32_t j = 0; j < row->len; j++) {
+            if (j > 0) total++; /* comma */
+            EzString *field = (EzString *)((char *)row->data + (size_t)j * sizeof(EzString));
+            total += field->len;
+        }
+        total++; /* newline */
+    }
+    char *buf = ez_arena_alloc(arena, (size_t)total + 1);
     int32_t pos = 0;
     for (int32_t i = 0; i < data->len; i++) {
         EzArray *row = (EzArray *)((char *)data->data + (size_t)i * sizeof(EzArray));

--- a/ezc/src/stdlib/ez_json.c
+++ b/ezc/src/stdlib/ez_json.c
@@ -43,7 +43,7 @@ void json_append_escaped(char *buf, int *pos, EzString s) {
 
 /* Helper: byte length of a map[string:string] value in JSON output. */
 static size_t json_map_val_len(EzString *val) {
-    if (val->len > 0 && (isdigit(val->data[0]) || val->data[0] == '-'))
+    if (val->len > 0 && (isdigit((unsigned char)val->data[0]) || val->data[0] == '-'))
         return (size_t)val->len;
     if (val->len == 4 && memcmp(val->data, "true", 4) == 0) return 4;
     if (val->len == 5 && memcmp(val->data, "false", 5) == 0) return 5;
@@ -75,7 +75,7 @@ EzString ez_json_encode_map(EzArena *arena, EzMap *m) {
         EzString *val = (EzString *)((char *)m->values + (size_t)i * (size_t)m->value_size);
         json_append_escaped(buf, &pos, *key);
         buf[pos++] = ':';
-        if (val->len > 0 && (isdigit(val->data[0]) || val->data[0] == '-')) {
+        if (val->len > 0 && (isdigit((unsigned char)val->data[0]) || val->data[0] == '-')) {
             memcpy(buf + pos, val->data, (size_t)val->len);
             pos += val->len;
         } else if (val->len == 4 && memcmp(val->data, "true", 4) == 0) {
@@ -282,7 +282,7 @@ EzString ez_json_encode_map_bool(EzArena *arena, EzMap *m) {
 /* --- Decoder --- */
 
 static void skip_ws(const char **s, const char *end) {
-    while (*s < end && isspace(**s)) (*s)++;
+    while (*s < end && isspace((unsigned char)**s)) (*s)++;
 }
 
 static EzString parse_json_string(EzArena *arena, const char **s, const char *end) {
@@ -308,7 +308,7 @@ static EzString parse_json_value_as_string(EzArena *arena, const char **s, const
 
     /* Number, bool, null — read until delimiter */
     const char *start = *s;
-    while (*s < end && **s != ',' && **s != '}' && **s != ']' && !isspace(**s)) (*s)++;
+    while (*s < end && **s != ',' && **s != '}' && **s != ']' && !isspace((unsigned char)**s)) (*s)++;
     return ez_string_new(arena, start, (int32_t)(*s - start));
 }
 

--- a/ezc/src/stdlib/ez_strings.c
+++ b/ezc/src/stdlib/ez_strings.c
@@ -12,7 +12,7 @@
 
 EzString ez_strings_to_upper(EzArena *arena, EzString s) {
     char *buf = ez_arena_alloc(arena, (size_t)s.len + 1);
-    for (int32_t i = 0; i < s.len; i++) buf[i] = (char)toupper(s.data[i]);
+    for (int32_t i = 0; i < s.len; i++) buf[i] = (char)toupper((unsigned char)s.data[i]);
     buf[s.len] = '\0';
     EzString r = { buf, s.len };
     return r;
@@ -20,7 +20,7 @@ EzString ez_strings_to_upper(EzArena *arena, EzString s) {
 
 EzString ez_strings_to_lower(EzArena *arena, EzString s) {
     char *buf = ez_arena_alloc(arena, (size_t)s.len + 1);
-    for (int32_t i = 0; i < s.len; i++) buf[i] = (char)tolower(s.data[i]);
+    for (int32_t i = 0; i < s.len; i++) buf[i] = (char)tolower((unsigned char)s.data[i]);
     buf[s.len] = '\0';
     EzString r = { buf, s.len };
     return r;
@@ -28,20 +28,20 @@ EzString ez_strings_to_lower(EzArena *arena, EzString s) {
 
 EzString ez_strings_trim(EzArena *arena, EzString s) {
     int32_t start = 0, end = s.len;
-    while (start < end && isspace(s.data[start])) start++;
-    while (end > start && isspace(s.data[end - 1])) end--;
+    while (start < end && isspace((unsigned char)s.data[start])) start++;
+    while (end > start && isspace((unsigned char)s.data[end - 1])) end--;
     return ez_string_new(arena, s.data + start, end - start);
 }
 
 EzString ez_strings_trim_left(EzArena *arena, EzString s) {
     int32_t start = 0;
-    while (start < s.len && isspace(s.data[start])) start++;
+    while (start < s.len && isspace((unsigned char)s.data[start])) start++;
     return ez_string_new(arena, s.data + start, s.len - start);
 }
 
 EzString ez_strings_trim_right(EzArena *arena, EzString s) {
     int32_t end = s.len;
-    while (end > 0 && isspace(s.data[end - 1])) end--;
+    while (end > 0 && isspace((unsigned char)s.data[end - 1])) end--;
     return ez_string_new(arena, s.data, end);
 }
 

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -2736,6 +2736,90 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
                     emit_unknown_stdlib_fn(tc, mod, mfn, node);
                     result = &TYPE_UNKNOWN;
                 }
+                /* Validate printf/sprintf/format: literal format string + directive types */
+                {
+                    bool is_fmt_fn = strcmp(mfn, "printf") == 0 ||
+                                     strcmp(mfn, "sprintf") == 0 ||
+                                     strcmp(mfn, "format") == 0;
+                    if (is_fmt_fn && node->data.call.arg_count >= 1) {
+                        AstNode *fmt_arg = node->data.call.args[0];
+                        if (fmt_arg->kind != NODE_STRING_VALUE) {
+                            diag_error_codef(tc->diag, "E3086",
+                                NODE_FILE(tc, fmt_arg), fmt_arg->token.line,
+                                fmt_arg->token.column, 0, mfn);
+                        } else {
+                            /* Walk format string, validate each directive against arg type */
+                            const char *fstr = fmt_arg->data.string_value.value;
+                            const char *p = fstr;
+                            int di = 1;
+                            while (*p) {
+                                if (*p != '%') { p++; continue; }
+                                p++;
+                                if (!*p) break;
+                                if (*p == '%') { p++; continue; }
+                                if (*p == 'n') {
+                                    diag_error_codef(tc->diag, "E3087",
+                                        NODE_FILE(tc, fmt_arg), fmt_arg->token.line,
+                                        fmt_arg->token.column, 0);
+                                    break;
+                                }
+                                /* Skip flags, width, precision, length modifier */
+                                while (*p == '-' || *p == '+' || *p == ' ' || *p == '0' || *p == '#') p++;
+                                while (*p >= '0' && *p <= '9') p++;
+                                if (*p == '.') { p++; while (*p >= '0' && *p <= '9') p++; }
+                                if (*p == 'h') { p++; if (*p == 'h') p++; }
+                                else if (*p == 'l') { p++; if (*p == 'l') p++; }
+                                else if (*p == 'L') p++;
+                                char spec = *p ? *p++ : 0;
+                                if (!spec) break;
+                                if (di >= node->data.call.arg_count) { di++; continue; }
+                                AstNode *darg = node->data.call.args[di];
+                                EzType *dt = resolve_expr(tc, darg);
+                                di++;
+                                if (!dt) continue;
+                                const char *expected = NULL;
+                                bool ok = false;
+                                switch (spec) {
+                                case 'd': case 'i':
+                                    expected = "int or char";
+                                    ok = dt->kind == TK_INT || dt->kind == TK_CHAR || dt->kind == TK_BYTE;
+                                    break;
+                                case 'u':
+                                    expected = "uint";
+                                    ok = dt->kind == TK_UINT || dt->kind == TK_BYTE;
+                                    break;
+                                case 'x': case 'X': case 'o':
+                                    expected = "int or uint";
+                                    ok = dt->kind == TK_INT || dt->kind == TK_UINT || dt->kind == TK_BYTE;
+                                    break;
+                                case 'f': case 'g': case 'e': case 'G': case 'E':
+                                    expected = "float";
+                                    ok = dt->kind == TK_FLOAT;
+                                    break;
+                                case 's':
+                                    expected = "string";
+                                    ok = dt->kind == TK_STRING;
+                                    break;
+                                case 'c':
+                                    expected = "char";
+                                    ok = dt->kind == TK_CHAR || dt->kind == TK_INT;
+                                    break;
+                                default:
+                                    ok = true;
+                                    break;
+                                }
+                                if (!ok && expected) {
+                                    char spec_str[2] = { spec, '\0' };
+                                    diag_error_codef(tc->diag, "E3088",
+                                        NODE_FILE(tc, darg), darg->token.line,
+                                        darg->token.column, 0,
+                                        mfn, spec_str, expected, di - 1,
+                                        type_name(dt));
+                                }
+                            }
+                        }
+                    }
+                }
                 /* Validate that non-format args are primitive types */
                 for (int ai = 1; ai < node->data.call.arg_count; ai++) {
                     EzType *arg_t = resolve_expr(tc, node->data.call.args[ai]);

--- a/ezc/src/util/error_codes.h
+++ b/ezc/src/util/error_codes.h
@@ -80,7 +80,8 @@
     EZ_ERROR("E2075", "syntax", "index expressions cannot have whitespace before the opening bracket; write 'arr[i]' with no space or newline") \
     EZ_ERROR("E2076", "syntax", "postfix operators ('++', '--', '^') cannot have whitespace before them; write 'x++', 'x--', or 'p^' with no space or newline") \
     EZ_ERROR("E2078", "syntax", "variable declarations must start with 'const' or 'mut'; did you mean 'const %s' or 'mut %s'?") \
-    EZ_ERROR("E2079", "syntax", "'nil' is a value, not a type; for a function that returns nothing, omit the '-> ...' clause")
+    EZ_ERROR("E2079", "syntax", "'nil' is a value, not a type; for a function that returns nothing, omit the '-> ...' clause") \
+    EZ_ERROR("E2080", "syntax", "invalid character in C header path; only [A-Za-z0-9./_+-] are permitted")
 
 /* --- E3xxx: Type Problems (Typechecker) --- */
 #define EZ_TYPE_ERRORS \

--- a/ezc/src/util/error_codes.h
+++ b/ezc/src/util/error_codes.h
@@ -157,7 +157,10 @@
     EZ_ERROR("E3082", "types", "wildcard type '?' cannot be used in named return positions; use an unnamed return instead") \
     EZ_ERROR("E3083", "types", "c_string() requires a raw C pointer; cannot convert a non-pointer type") \
     EZ_ERROR("E3084", "types", "type_of() expects a value, not a type name; use type_of(instance) instead") \
-    EZ_ERROR("E3085", "types", "'in' operator type mismatch: cannot check if '%s' is in '%s'")
+    EZ_ERROR("E3085", "types", "'in' operator type mismatch: cannot check if '%s' is in '%s'") \
+    EZ_ERROR("E3086", "types", "fmt.%s format string must be a string literal; use string interpolation for dynamic values") \
+    EZ_ERROR("E3087", "types", "%%n is not permitted in fmt format strings") \
+    EZ_ERROR("E3088", "types", "fmt.%s format directive '%%%s' expects %s but argument %d has type '%s'")
 
 /* --- E4xxx: Name Problems (References) --- */
 #define EZ_REFERENCE_ERRORS \


### PR DESCRIPTION
## Summary

- Add `ez fmt` command for source code formatting
- Fix 5 security and correctness bugs across the compiler, runtime, and stdlib

## Feature

- **`ez fmt` command** — in-place source formatting with `--check` CI gate. Closes #1564.

## Bug Fixes

- **Remove `--diff` from ez fmt** — misleading output; dropped from v1.
- **ctype.h UB** — missing `(unsigned char)` casts across lexer, parser, codegen, stdlib. Closes #1616.
- **C injection via `import c"..."`** — header path now validated against `[A-Za-z0-9./_+-]` whitelist (E2080). Closes #1618.
- **csv heap overflow** — `ez_csv_stringify` now uses two-pass exact sizing instead of fixed 64-byte-per-row estimate. Closes #1617.
- **Wrong sort comparators** — `arrays.sort_asc/desc` now dispatches correct comparators for float and string element types. Closes #1632.
- **fmt format string vulnerability** — dynamic format strings rejected (E3086), `%n` banned (E3087), directive/type mismatches caught at compile time (E3088). Closes #1633.