### PR TITLE
fix(parser): accept bare '_ = expr' at statement position (#1647)

### DIFF
--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -39,6 +39,7 @@ static AstNode *parse_statement(Parser *p);
 static AstNode *parse_expression(Parser *p, Precedence prec);
 static AstNode *parse_block_statement(Parser *p);
 static AstNode *parse_struct_literal(Parser *p, const char *name);
+static AstNode *maybe_apply_or_return(Parser *p, AstNode *var_decl);
 
 /* --- Struct name pre-scan --- */
 
@@ -1121,6 +1122,108 @@ static AstNode *parse_expression(Parser *p, Precedence prec) {
 
 /* --- Statement Parsing --- */
 
+/* If peek is or_return, consume it and desugar
+ *
+ *     <var_decl with value = expr> or_return
+ *
+ * into a block:
+ *
+ *     mut _tmp = expr
+ *     if _tmp.v1 != nil { return _tmp.v1 }
+ *     <var_decl with value = _tmp.v0>
+ *
+ * Returns the desugared block, or NULL if no or_return was present
+ * (caller keeps the original var_decl untouched). */
+static AstNode *maybe_apply_or_return(Parser *p, AstNode *var_decl) {
+    if (!peek_token_is(p, TOK_OR_RETURN)) return NULL;
+    next_token(p); /* consume or_return */
+
+    static int or_return_counter = 0;
+    char *tmp_name = arena_alloc(p->arena, EZ_TMP_NAME_BUF);
+    snprintf(tmp_name, EZ_TMP_NAME_BUF, "_ez_or%d", or_return_counter++);
+
+    AstNode *block = ast_alloc(p->arena, NODE_BLOCK_STMT, p->cur_token);
+    block->data.block.cap = 4;
+    block->data.block.count = 0;
+    block->data.block.stmts = arena_alloc(p->arena, sizeof(AstNode *) * block->data.block.cap);
+
+    /* _tmp = expr */
+    AstNode *tmp_decl = ast_alloc(p->arena, NODE_VAR_DECL, p->cur_token);
+    tmp_decl->data.var_decl.mutable = true;
+    tmp_decl->data.var_decl.name = tmp_name;
+    tmp_decl->data.var_decl.type_name = NULL;
+    tmp_decl->data.var_decl.value = var_decl->data.var_decl.value;
+    block->data.block.stmts[block->data.block.count++] = tmp_decl;
+
+    /* if (_tmp.v1 != nil) { return _tmp.v1 } */
+    AstNode *if_stmt = ast_alloc(p->arena, NODE_IF_STMT, p->cur_token);
+    AstNode *err_access = ast_alloc(p->arena, NODE_MEMBER_EXPR, p->cur_token);
+    AstNode *tmp_label = ast_alloc(p->arena, NODE_LABEL, p->cur_token);
+    tmp_label->data.label.value = tmp_name;
+    err_access->data.member.object = tmp_label;
+    err_access->data.member.member = "v1";
+    AstNode *nil_val = ast_alloc(p->arena, NODE_NIL_VALUE, p->cur_token);
+    AstNode *cond = ast_alloc(p->arena, NODE_INFIX_EXPR, p->cur_token);
+    cond->data.infix.left = err_access;
+    cond->data.infix.op = "!=";
+    cond->data.infix.right = nil_val;
+    if_stmt->data.if_stmt.condition = cond;
+
+    AstNode *ret_block = ast_alloc(p->arena, NODE_BLOCK_STMT, p->cur_token);
+    ret_block->data.block.cap = 1;
+    ret_block->data.block.count = 0;
+    ret_block->data.block.stmts = arena_alloc(p->arena, sizeof(AstNode *));
+    AstNode *ret_stmt = ast_alloc(p->arena, NODE_RETURN_STMT, p->cur_token);
+    AstNode *err_access2 = ast_alloc(p->arena, NODE_MEMBER_EXPR, p->cur_token);
+    AstNode *tmp_label2 = ast_alloc(p->arena, NODE_LABEL, p->cur_token);
+    tmp_label2->data.label.value = tmp_name;
+    err_access2->data.member.object = tmp_label2;
+    err_access2->data.member.member = "v1";
+    ret_stmt->data.return_stmt.values = arena_alloc(p->arena, sizeof(AstNode *));
+    ret_stmt->data.return_stmt.values[0] = err_access2;
+    ret_stmt->data.return_stmt.count = 1;
+    ret_block->data.block.stmts[ret_block->data.block.count++] = ret_stmt;
+    if_stmt->data.if_stmt.consequence = ret_block;
+    if_stmt->data.if_stmt.alternative = NULL;
+    block->data.block.stmts[block->data.block.count++] = if_stmt;
+
+    /* x = _tmp.v0 */
+    AstNode *var = ast_alloc(p->arena, NODE_VAR_DECL, p->cur_token);
+    var->data.var_decl.mutable = var_decl->data.var_decl.mutable;
+    var->data.var_decl.name = var_decl->data.var_decl.name;
+    var->data.var_decl.type_name = var_decl->data.var_decl.type_name;
+    AstNode *val_access = ast_alloc(p->arena, NODE_MEMBER_EXPR, p->cur_token);
+    AstNode *tmp_label3 = ast_alloc(p->arena, NODE_LABEL, p->cur_token);
+    tmp_label3->data.label.value = tmp_name;
+    val_access->data.member.object = tmp_label3;
+    val_access->data.member.member = "v0";
+    var->data.var_decl.value = val_access;
+    block->data.block.stmts[block->data.block.count++] = var;
+
+    return block;
+}
+
+/* Bare throwaway: `_ = expr` (no mut/const keyword) at statement position.
+ * Desugars to a var_decl(name="_", mutable=true), which the typechecker
+ * and codegen already special-case to skip symbol creation and emit
+ * `(void)(expr);`. or_return is supported via the shared helper. */
+static AstNode *parse_discard_statement(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_VAR_DECL, p->cur_token);
+    node->data.var_decl.mutable = true;
+    node->data.var_decl.name = "_";
+    node->data.var_decl.type_name = NULL;
+    node->data.var_decl.value = NULL;
+
+    next_token(p); /* consume = */
+    next_token(p); /* move to RHS */
+    node->data.var_decl.value = parse_expression(p, PREC_LOWEST);
+    if (!node->data.var_decl.value) return NULL;
+
+    AstNode *desugared = maybe_apply_or_return(p, node);
+    if (desugared) return desugared;
+    return node;
+}
+
 static AstNode *parse_var_declaration(Parser *p) {
     AstNode *node = ast_alloc(p->arena, NODE_VAR_DECL, p->cur_token);
     node->data.var_decl.mutable = (p->cur_token.type == TOK_MUT);
@@ -1259,82 +1362,8 @@ static AstNode *parse_var_declaration(Parser *p) {
         next_token(p);
         node->data.var_decl.value = parse_expression(p, PREC_LOWEST);
 
-        /* Check for or_return: mut x = expr or_return */
-        if (peek_token_is(p, TOK_OR_RETURN)) {
-            next_token(p); /* consume or_return */
-            /*
-             * Expand into:
-             *   __auto_type _tmp = expr
-             *   if (_tmp.v1 != NULL) { return (RetType){0, ..., _tmp.v1}; }
-             *   type x = _tmp.v0
-             */
-            static int or_return_counter = 0;
-            char *tmp_name = arena_alloc(p->arena, EZ_TMP_NAME_BUF);
-            snprintf(tmp_name, EZ_TMP_NAME_BUF, "_ez_or%d", or_return_counter++);
-
-            AstNode *block = ast_alloc(p->arena, NODE_BLOCK_STMT, p->cur_token);
-            block->data.block.cap = 4;
-            block->data.block.count = 0;
-            block->data.block.stmts = arena_alloc(p->arena, sizeof(AstNode *) * block->data.block.cap);
-
-            /* _tmp = expr */
-            AstNode *tmp_decl = ast_alloc(p->arena, NODE_VAR_DECL, p->cur_token);
-            tmp_decl->data.var_decl.mutable = true;
-            tmp_decl->data.var_decl.name = tmp_name;
-            tmp_decl->data.var_decl.type_name = NULL;
-            tmp_decl->data.var_decl.value = node->data.var_decl.value;
-            block->data.block.stmts[block->data.block.count++] = tmp_decl;
-
-            /* if (_tmp.v1 != nil) { return _tmp.v1 } */
-            AstNode *if_stmt = ast_alloc(p->arena, NODE_IF_STMT, p->cur_token);
-            /* condition: _tmp.v1 != nil */
-            AstNode *err_access = ast_alloc(p->arena, NODE_MEMBER_EXPR, p->cur_token);
-            AstNode *tmp_label = ast_alloc(p->arena, NODE_LABEL, p->cur_token);
-            tmp_label->data.label.value = tmp_name;
-            err_access->data.member.object = tmp_label;
-            err_access->data.member.member = "v1";
-            AstNode *nil_val = ast_alloc(p->arena, NODE_NIL_VALUE, p->cur_token);
-            AstNode *cond = ast_alloc(p->arena, NODE_INFIX_EXPR, p->cur_token);
-            cond->data.infix.left = err_access;
-            cond->data.infix.op = "!=";
-            cond->data.infix.right = nil_val;
-            if_stmt->data.if_stmt.condition = cond;
-
-            /* consequence: return block; just re-return the error */
-            AstNode *ret_block = ast_alloc(p->arena, NODE_BLOCK_STMT, p->cur_token);
-            ret_block->data.block.cap = 1;
-            ret_block->data.block.count = 0;
-            ret_block->data.block.stmts = arena_alloc(p->arena, sizeof(AstNode *));
-            AstNode *ret_stmt = ast_alloc(p->arena, NODE_RETURN_STMT, p->cur_token);
-            /* Return the error as the last value */
-            AstNode *err_access2 = ast_alloc(p->arena, NODE_MEMBER_EXPR, p->cur_token);
-            AstNode *tmp_label2 = ast_alloc(p->arena, NODE_LABEL, p->cur_token);
-            tmp_label2->data.label.value = tmp_name;
-            err_access2->data.member.object = tmp_label2;
-            err_access2->data.member.member = "v1";
-            ret_stmt->data.return_stmt.values = arena_alloc(p->arena, sizeof(AstNode *));
-            ret_stmt->data.return_stmt.values[0] = err_access2;
-            ret_stmt->data.return_stmt.count = 1;
-            ret_block->data.block.stmts[ret_block->data.block.count++] = ret_stmt;
-            if_stmt->data.if_stmt.consequence = ret_block;
-            if_stmt->data.if_stmt.alternative = NULL;
-            block->data.block.stmts[block->data.block.count++] = if_stmt;
-
-            /* x = _tmp.v0 */
-            AstNode *var = ast_alloc(p->arena, NODE_VAR_DECL, p->cur_token);
-            var->data.var_decl.mutable = node->data.var_decl.mutable;
-            var->data.var_decl.name = node->data.var_decl.name;
-            var->data.var_decl.type_name = node->data.var_decl.type_name;
-            AstNode *val_access = ast_alloc(p->arena, NODE_MEMBER_EXPR, p->cur_token);
-            AstNode *tmp_label3 = ast_alloc(p->arena, NODE_LABEL, p->cur_token);
-            tmp_label3->data.label.value = tmp_name;
-            val_access->data.member.object = tmp_label3;
-            val_access->data.member.member = "v0";
-            var->data.var_decl.value = val_access;
-            block->data.block.stmts[block->data.block.count++] = var;
-
-            return block;
-        }
+        AstNode *desugared = maybe_apply_or_return(p, node);
+        if (desugared) return desugared;
     }
 
     return node;
@@ -2487,6 +2516,18 @@ static AstNode *parse_statement(Parser *p) {
         return parse_statement(p);
     case TOK_ENSURE:
         return parse_ensure_statement(p);
+    case TOK_BLANK:
+        /* Bare throwaway: `_ = expr` discards the RHS without creating
+         * a symbol. Any other use of `_` at statement position (bare
+         * `_`, `_ +=`, `_, x = ...`) is invalid. */
+        if (peek_token_is(p, TOK_ASSIGN)) {
+            return parse_discard_statement(p);
+        }
+        diag_error_msg(p->diag, "E2002",
+            strdup("unexpected token '_'; the throwaway '_' is only valid as the entire left-hand side of an assignment"),
+            p->file, p->cur_token.line, p->cur_token.column, 0);
+        synchronize(p);
+        return NULL;
     default: {
         /* IDENT IDENT at statement position means the user tried to
          * declare a variable but typed the wrong leading keyword


### PR DESCRIPTION
## Summary

- Parser now accepts bare `_ = expr` at statement position; previously E2002 rejected it even though E5011 suggested using `_` to discard.
- Routes the bare form through the existing `mut _ =` lowering, so typechecker/codegen already handle it correctly (no new AST node, no new error code, no shadowing/scope changes).
- `or_return` desugaring extracted into a shared helper so `_ = f() or_return` works for free.

## Behavior

| Form | Before | After |
|------|--------|-------|
| `_ = f()` | E2002 | OK |
| `mut _ = f()` | OK | OK |
| `const _ = f()` | OK | OK |
| `_ = println("hi")` | n/a | E3038 (void RHS) |
| `_ += f()` | E2002 (generic) | E2002 (clearer message) |
| `_, x = f()` | E2002 (generic) | E2002 (clearer message) |
| `_` alone | E2002 (generic) | E2002 (clearer message) |
| `_ = f() or_return` | n/a | OK |

Closes #1647.