### PR TITLE
Bug fixes: throwaway parsing, file-scope init, opaque types

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -3,7 +3,7 @@
 > Auto-generated from `ezc/src/util/error_codes.h`. Do not edit manually.
 > Run `./scripts/generate_errors.sh` to regenerate.
 
-**Total: 187 codes** (172 errors, 15 warnings)
+**Total: 188 codes** (173 errors, 15 warnings)
 
 ---
 
@@ -166,6 +166,7 @@
 | `E5008` | arguments | wrong number of arguments; the function expects a different count than was provided |
 | `E5009` | arguments | invalid base for integer conversion; base must be between 2 and 36 |
 | `E5011` | usage | return value of '%s' is not used; assign it to a variable or use '_' to discard |
+| `E5013` | usage | function calls are not allowed in file-scope initializers; move this declaration into a function body |
 | `E5015` | usage | postfix ++ and -- require a variable, not a value or expression |
 | `E5023` | usage | cannot use '%s' on type '%s'; only integer types support increment/decrement |
 | `E5024` | usage | return type mismatch: cannot return signed '%s' as unsigned '%s' |
@@ -231,4 +232,4 @@
 
 ---
 
-*Generated on 2026-05-12 14:42:19 UTC*
+*Generated on 2026-05-19 17:03:11 UTC*

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -3,7 +3,7 @@
 > Auto-generated from `ezc/src/util/error_codes.h`. Do not edit manually.
 > Run `./scripts/generate_errors.sh` to regenerate.
 
-**Total: 188 codes** (173 errors, 15 warnings)
+**Total: 189 codes** (174 errors, 15 warnings)
 
 ---
 
@@ -166,6 +166,7 @@
 | `E5008` | arguments | wrong number of arguments; the function expects a different count than was provided |
 | `E5009` | arguments | invalid base for integer conversion; base must be between 2 and 36 |
 | `E5011` | usage | return value of '%s' is not used; assign it to a variable or use '_' to discard |
+| `E5012` | usage | the throwaway '_' is only meaningful when discarding the result of a function call; the right-hand side has no return value to discard |
 | `E5013` | usage | function calls are not allowed in file-scope initializers; move this declaration into a function body |
 | `E5015` | usage | postfix ++ and -- require a variable, not a value or expression |
 | `E5023` | usage | cannot use '%s' on type '%s'; only integer types support increment/decrement |
@@ -232,4 +233,4 @@
 
 ---
 
-*Generated on 2026-05-19 17:03:11 UTC*
+*Generated on 2026-05-19 17:05:50 UTC*

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -233,4 +233,4 @@
 
 ---
 
-*Generated on 2026-05-19 17:05:50 UTC*
+*Generated on 2026-05-19 17:37:16 UTC*

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -194,6 +194,19 @@ static const char *ez_type_to_c_cg(CodeGen *cg, const char *type_name) {
     if (strcmp(type_name, "Error") == 0 || strcmp(type_name, "error") == 0) return "EzError *";
     if (strcmp(type_name, "HttpRequest") == 0) return "EzRequest";
     if (strcmp(type_name, "HttpResponse") == 0) return "EzResponse";
+    /* Stdlib opaque types: scalar path uses __auto_type and never reaches
+     * this resolver, but [T] / map[_:T] / struct fields write the type
+     * name explicitly and need it mapped here. Without this, the fallback
+     * below produces EzStruct_<Name>, which no header defines, and clang
+     * fails on the generated C. */
+    if (strcmp(type_name, "Thread") == 0)   return "EzThread";
+    if (strcmp(type_name, "Mutex") == 0)    return "EzMutex";
+    if (strcmp(type_name, "SpinLock") == 0) return "EzSpinLock";
+    if (strcmp(type_name, "Channel") == 0)  return "EzChannel";
+    if (strcmp(type_name, "Socket") == 0)   return "EzSocket";
+    if (strcmp(type_name, "Listener") == 0) return "EzSocket";
+    if (strcmp(type_name, "Database") == 0) return "EzSqlite";
+    if (strcmp(type_name, "Router") == 0)   return "EzRouter";
     if (strcmp(type_name, "func") == 0)  return "void *"; /* legacy bare func; cast at call site */
     if (strncmp(type_name, "func(", 5) == 0) return "void *"; /* typed func; same C storage, signature lives in casts */
 

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -39,6 +39,7 @@ static AstNode *parse_statement(Parser *p);
 static AstNode *parse_expression(Parser *p, Precedence prec);
 static AstNode *parse_block_statement(Parser *p);
 static AstNode *parse_struct_literal(Parser *p, const char *name);
+static AstNode *maybe_apply_or_return(Parser *p, AstNode *var_decl);
 
 /* --- Struct name pre-scan --- */
 
@@ -1121,6 +1122,108 @@ static AstNode *parse_expression(Parser *p, Precedence prec) {
 
 /* --- Statement Parsing --- */
 
+/* If peek is or_return, consume it and desugar
+ *
+ *     <var_decl with value = expr> or_return
+ *
+ * into a block:
+ *
+ *     mut _tmp = expr
+ *     if _tmp.v1 != nil { return _tmp.v1 }
+ *     <var_decl with value = _tmp.v0>
+ *
+ * Returns the desugared block, or NULL if no or_return was present
+ * (caller keeps the original var_decl untouched). */
+static AstNode *maybe_apply_or_return(Parser *p, AstNode *var_decl) {
+    if (!peek_token_is(p, TOK_OR_RETURN)) return NULL;
+    next_token(p); /* consume or_return */
+
+    static int or_return_counter = 0;
+    char *tmp_name = arena_alloc(p->arena, EZ_TMP_NAME_BUF);
+    snprintf(tmp_name, EZ_TMP_NAME_BUF, "_ez_or%d", or_return_counter++);
+
+    AstNode *block = ast_alloc(p->arena, NODE_BLOCK_STMT, p->cur_token);
+    block->data.block.cap = 4;
+    block->data.block.count = 0;
+    block->data.block.stmts = arena_alloc(p->arena, sizeof(AstNode *) * block->data.block.cap);
+
+    /* _tmp = expr */
+    AstNode *tmp_decl = ast_alloc(p->arena, NODE_VAR_DECL, p->cur_token);
+    tmp_decl->data.var_decl.mutable = true;
+    tmp_decl->data.var_decl.name = tmp_name;
+    tmp_decl->data.var_decl.type_name = NULL;
+    tmp_decl->data.var_decl.value = var_decl->data.var_decl.value;
+    block->data.block.stmts[block->data.block.count++] = tmp_decl;
+
+    /* if (_tmp.v1 != nil) { return _tmp.v1 } */
+    AstNode *if_stmt = ast_alloc(p->arena, NODE_IF_STMT, p->cur_token);
+    AstNode *err_access = ast_alloc(p->arena, NODE_MEMBER_EXPR, p->cur_token);
+    AstNode *tmp_label = ast_alloc(p->arena, NODE_LABEL, p->cur_token);
+    tmp_label->data.label.value = tmp_name;
+    err_access->data.member.object = tmp_label;
+    err_access->data.member.member = "v1";
+    AstNode *nil_val = ast_alloc(p->arena, NODE_NIL_VALUE, p->cur_token);
+    AstNode *cond = ast_alloc(p->arena, NODE_INFIX_EXPR, p->cur_token);
+    cond->data.infix.left = err_access;
+    cond->data.infix.op = "!=";
+    cond->data.infix.right = nil_val;
+    if_stmt->data.if_stmt.condition = cond;
+
+    AstNode *ret_block = ast_alloc(p->arena, NODE_BLOCK_STMT, p->cur_token);
+    ret_block->data.block.cap = 1;
+    ret_block->data.block.count = 0;
+    ret_block->data.block.stmts = arena_alloc(p->arena, sizeof(AstNode *));
+    AstNode *ret_stmt = ast_alloc(p->arena, NODE_RETURN_STMT, p->cur_token);
+    AstNode *err_access2 = ast_alloc(p->arena, NODE_MEMBER_EXPR, p->cur_token);
+    AstNode *tmp_label2 = ast_alloc(p->arena, NODE_LABEL, p->cur_token);
+    tmp_label2->data.label.value = tmp_name;
+    err_access2->data.member.object = tmp_label2;
+    err_access2->data.member.member = "v1";
+    ret_stmt->data.return_stmt.values = arena_alloc(p->arena, sizeof(AstNode *));
+    ret_stmt->data.return_stmt.values[0] = err_access2;
+    ret_stmt->data.return_stmt.count = 1;
+    ret_block->data.block.stmts[ret_block->data.block.count++] = ret_stmt;
+    if_stmt->data.if_stmt.consequence = ret_block;
+    if_stmt->data.if_stmt.alternative = NULL;
+    block->data.block.stmts[block->data.block.count++] = if_stmt;
+
+    /* x = _tmp.v0 */
+    AstNode *var = ast_alloc(p->arena, NODE_VAR_DECL, p->cur_token);
+    var->data.var_decl.mutable = var_decl->data.var_decl.mutable;
+    var->data.var_decl.name = var_decl->data.var_decl.name;
+    var->data.var_decl.type_name = var_decl->data.var_decl.type_name;
+    AstNode *val_access = ast_alloc(p->arena, NODE_MEMBER_EXPR, p->cur_token);
+    AstNode *tmp_label3 = ast_alloc(p->arena, NODE_LABEL, p->cur_token);
+    tmp_label3->data.label.value = tmp_name;
+    val_access->data.member.object = tmp_label3;
+    val_access->data.member.member = "v0";
+    var->data.var_decl.value = val_access;
+    block->data.block.stmts[block->data.block.count++] = var;
+
+    return block;
+}
+
+/* Bare throwaway: `_ = expr` (no mut/const keyword) at statement position.
+ * Desugars to a var_decl(name="_", mutable=true), which the typechecker
+ * and codegen already special-case to skip symbol creation and emit
+ * `(void)(expr);`. or_return is supported via the shared helper. */
+static AstNode *parse_discard_statement(Parser *p) {
+    AstNode *node = ast_alloc(p->arena, NODE_VAR_DECL, p->cur_token);
+    node->data.var_decl.mutable = true;
+    node->data.var_decl.name = "_";
+    node->data.var_decl.type_name = NULL;
+    node->data.var_decl.value = NULL;
+
+    next_token(p); /* consume = */
+    next_token(p); /* move to RHS */
+    node->data.var_decl.value = parse_expression(p, PREC_LOWEST);
+    if (!node->data.var_decl.value) return NULL;
+
+    AstNode *desugared = maybe_apply_or_return(p, node);
+    if (desugared) return desugared;
+    return node;
+}
+
 static AstNode *parse_var_declaration(Parser *p) {
     AstNode *node = ast_alloc(p->arena, NODE_VAR_DECL, p->cur_token);
     node->data.var_decl.mutable = (p->cur_token.type == TOK_MUT);
@@ -1259,82 +1362,8 @@ static AstNode *parse_var_declaration(Parser *p) {
         next_token(p);
         node->data.var_decl.value = parse_expression(p, PREC_LOWEST);
 
-        /* Check for or_return: mut x = expr or_return */
-        if (peek_token_is(p, TOK_OR_RETURN)) {
-            next_token(p); /* consume or_return */
-            /*
-             * Expand into:
-             *   __auto_type _tmp = expr
-             *   if (_tmp.v1 != NULL) { return (RetType){0, ..., _tmp.v1}; }
-             *   type x = _tmp.v0
-             */
-            static int or_return_counter = 0;
-            char *tmp_name = arena_alloc(p->arena, EZ_TMP_NAME_BUF);
-            snprintf(tmp_name, EZ_TMP_NAME_BUF, "_ez_or%d", or_return_counter++);
-
-            AstNode *block = ast_alloc(p->arena, NODE_BLOCK_STMT, p->cur_token);
-            block->data.block.cap = 4;
-            block->data.block.count = 0;
-            block->data.block.stmts = arena_alloc(p->arena, sizeof(AstNode *) * block->data.block.cap);
-
-            /* _tmp = expr */
-            AstNode *tmp_decl = ast_alloc(p->arena, NODE_VAR_DECL, p->cur_token);
-            tmp_decl->data.var_decl.mutable = true;
-            tmp_decl->data.var_decl.name = tmp_name;
-            tmp_decl->data.var_decl.type_name = NULL;
-            tmp_decl->data.var_decl.value = node->data.var_decl.value;
-            block->data.block.stmts[block->data.block.count++] = tmp_decl;
-
-            /* if (_tmp.v1 != nil) { return _tmp.v1 } */
-            AstNode *if_stmt = ast_alloc(p->arena, NODE_IF_STMT, p->cur_token);
-            /* condition: _tmp.v1 != nil */
-            AstNode *err_access = ast_alloc(p->arena, NODE_MEMBER_EXPR, p->cur_token);
-            AstNode *tmp_label = ast_alloc(p->arena, NODE_LABEL, p->cur_token);
-            tmp_label->data.label.value = tmp_name;
-            err_access->data.member.object = tmp_label;
-            err_access->data.member.member = "v1";
-            AstNode *nil_val = ast_alloc(p->arena, NODE_NIL_VALUE, p->cur_token);
-            AstNode *cond = ast_alloc(p->arena, NODE_INFIX_EXPR, p->cur_token);
-            cond->data.infix.left = err_access;
-            cond->data.infix.op = "!=";
-            cond->data.infix.right = nil_val;
-            if_stmt->data.if_stmt.condition = cond;
-
-            /* consequence: return block; just re-return the error */
-            AstNode *ret_block = ast_alloc(p->arena, NODE_BLOCK_STMT, p->cur_token);
-            ret_block->data.block.cap = 1;
-            ret_block->data.block.count = 0;
-            ret_block->data.block.stmts = arena_alloc(p->arena, sizeof(AstNode *));
-            AstNode *ret_stmt = ast_alloc(p->arena, NODE_RETURN_STMT, p->cur_token);
-            /* Return the error as the last value */
-            AstNode *err_access2 = ast_alloc(p->arena, NODE_MEMBER_EXPR, p->cur_token);
-            AstNode *tmp_label2 = ast_alloc(p->arena, NODE_LABEL, p->cur_token);
-            tmp_label2->data.label.value = tmp_name;
-            err_access2->data.member.object = tmp_label2;
-            err_access2->data.member.member = "v1";
-            ret_stmt->data.return_stmt.values = arena_alloc(p->arena, sizeof(AstNode *));
-            ret_stmt->data.return_stmt.values[0] = err_access2;
-            ret_stmt->data.return_stmt.count = 1;
-            ret_block->data.block.stmts[ret_block->data.block.count++] = ret_stmt;
-            if_stmt->data.if_stmt.consequence = ret_block;
-            if_stmt->data.if_stmt.alternative = NULL;
-            block->data.block.stmts[block->data.block.count++] = if_stmt;
-
-            /* x = _tmp.v0 */
-            AstNode *var = ast_alloc(p->arena, NODE_VAR_DECL, p->cur_token);
-            var->data.var_decl.mutable = node->data.var_decl.mutable;
-            var->data.var_decl.name = node->data.var_decl.name;
-            var->data.var_decl.type_name = node->data.var_decl.type_name;
-            AstNode *val_access = ast_alloc(p->arena, NODE_MEMBER_EXPR, p->cur_token);
-            AstNode *tmp_label3 = ast_alloc(p->arena, NODE_LABEL, p->cur_token);
-            tmp_label3->data.label.value = tmp_name;
-            val_access->data.member.object = tmp_label3;
-            val_access->data.member.member = "v0";
-            var->data.var_decl.value = val_access;
-            block->data.block.stmts[block->data.block.count++] = var;
-
-            return block;
-        }
+        AstNode *desugared = maybe_apply_or_return(p, node);
+        if (desugared) return desugared;
     }
 
     return node;
@@ -2487,6 +2516,18 @@ static AstNode *parse_statement(Parser *p) {
         return parse_statement(p);
     case TOK_ENSURE:
         return parse_ensure_statement(p);
+    case TOK_BLANK:
+        /* Bare throwaway: `_ = expr` discards the RHS without creating
+         * a symbol. Any other use of `_` at statement position (bare
+         * `_`, `_ +=`, `_, x = ...`) is invalid. */
+        if (peek_token_is(p, TOK_ASSIGN)) {
+            return parse_discard_statement(p);
+        }
+        diag_error_msg(p->diag, "E2002",
+            strdup("unexpected token '_'; the throwaway '_' is only valid as the entire left-hand side of an assignment"),
+            p->file, p->cur_token.line, p->cur_token.column, 0);
+        synchronize(p);
+        return NULL;
     default: {
         /* IDENT IDENT at statement position means the user tried to
          * declare a variable but typed the wrong leading keyword

--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -1207,6 +1207,18 @@ static AstNode *maybe_apply_or_return(Parser *p, AstNode *var_decl) {
  * Desugars to a var_decl(name="_", mutable=true), which the typechecker
  * and codegen already special-case to skip symbol creation and emit
  * `(void)(expr);`. or_return is supported via the shared helper. */
+/* E5012: the throwaway '_' is only meaningful when the RHS is a
+ * function call. Literal/identifier/arithmetic RHSes have no return
+ * value to discard and no side effect to run, so `_ = 32` etc. are
+ * dead code with a misleading name. Checked at parse time (before
+ * or_return desugaring) so the user-written RHS, not the rewritten
+ * member-access, is what gets validated. */
+static void check_throwaway_target(Parser *p, AstNode *value) {
+    if (!value || value->kind == NODE_CALL_EXPR) return;
+    diag_error_code(p->diag, "E5012",
+        p->file, value->token.line, value->token.column, 0);
+}
+
 static AstNode *parse_discard_statement(Parser *p) {
     AstNode *node = ast_alloc(p->arena, NODE_VAR_DECL, p->cur_token);
     node->data.var_decl.mutable = true;
@@ -1218,6 +1230,8 @@ static AstNode *parse_discard_statement(Parser *p) {
     next_token(p); /* move to RHS */
     node->data.var_decl.value = parse_expression(p, PREC_LOWEST);
     if (!node->data.var_decl.value) return NULL;
+
+    check_throwaway_target(p, node->data.var_decl.value);
 
     AstNode *desugared = maybe_apply_or_return(p, node);
     if (desugared) return desugared;
@@ -1361,6 +1375,11 @@ static AstNode *parse_var_declaration(Parser *p) {
         next_token(p); /* skip = */
         next_token(p);
         node->data.var_decl.value = parse_expression(p, PREC_LOWEST);
+
+        if (node->data.var_decl.value &&
+            strcmp(node->data.var_decl.name, "_") == 0) {
+            check_throwaway_target(p, node->data.var_decl.value);
+        }
 
         AstNode *desugared = maybe_apply_or_return(p, node);
         if (desugared) return desugared;

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -4959,6 +4959,60 @@ static void check_reserved_name(TypeChecker *tc, const char *name, const char *f
 
 static void check_statement(TypeChecker *tc, AstNode *node);
 
+/* Walk an expression tree looking for a function call anywhere inside.
+ * Used by the file-scope initializer guard (E5013): runtime calls in
+ * a top-level var_decl produce invalid C (free-standing init or
+ * non-constant initializer), so the EZ side must reject them with
+ * a real diagnostic before codegen runs. */
+static bool expr_contains_call(AstNode *node) {
+    if (!node) return false;
+    switch (node->kind) {
+    case NODE_CALL_EXPR:
+        return true;
+    case NODE_PREFIX_EXPR:
+        return expr_contains_call(node->data.prefix.right);
+    case NODE_INFIX_EXPR:
+        return expr_contains_call(node->data.infix.left) ||
+               expr_contains_call(node->data.infix.right);
+    case NODE_POSTFIX_EXPR:
+        return expr_contains_call(node->data.postfix.left);
+    case NODE_INDEX_EXPR:
+        return expr_contains_call(node->data.index_expr.left) ||
+               expr_contains_call(node->data.index_expr.index);
+    case NODE_MEMBER_EXPR:
+        return expr_contains_call(node->data.member.object);
+    case NODE_RANGE_EXPR:
+        return expr_contains_call(node->data.range_expr.start) ||
+               expr_contains_call(node->data.range_expr.end) ||
+               expr_contains_call(node->data.range_expr.step);
+    case NODE_CAST_EXPR:
+        return expr_contains_call(node->data.cast.value);
+    case NODE_ARRAY_VALUE:
+        for (int i = 0; i < node->data.array_value.count; i++) {
+            if (expr_contains_call(node->data.array_value.elements[i])) return true;
+        }
+        return false;
+    case NODE_MAP_VALUE:
+        for (int i = 0; i < node->data.map_value.count; i++) {
+            if (expr_contains_call(node->data.map_value.keys[i])) return true;
+            if (expr_contains_call(node->data.map_value.values[i])) return true;
+        }
+        return false;
+    case NODE_STRUCT_VALUE:
+        for (int i = 0; i < node->data.struct_value.count; i++) {
+            if (expr_contains_call(node->data.struct_value.field_values[i])) return true;
+        }
+        return false;
+    case NODE_INTERPOLATED_STRING:
+        for (int i = 0; i < node->data.interpolated_string.part_count; i++) {
+            if (expr_contains_call(node->data.interpolated_string.parts[i])) return true;
+        }
+        return false;
+    default:
+        return false;
+    }
+}
+
 /* Check if ALL paths through a block end in a return statement */
 static bool block_has_return(AstNode *node); /* forward declaration */
 
@@ -5117,6 +5171,17 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
 
     switch (node->kind) {
     case NODE_VAR_DECL: {
+        /* E5013: file-scope initializers cannot contain function calls.
+         * A runtime call as an initializer would either need a module-init
+         * function (which EZ does not generate) or produce invalid C
+         * (non-constant initializer / free-standing statement at file
+         * scope). Catch it on the EZ side so the user sees a real
+         * diagnostic instead of a clang error pointing at the generated C. */
+        if (tc->func_depth == 0 && node->data.var_decl.value &&
+            expr_contains_call(node->data.var_decl.value)) {
+            diag_error_code(tc->diag, "E5013",
+                NODE_FILE(tc, node), node->token.line, node->token.column, 0);
+        }
         /* E3038: void cannot be used as variable type */
         if (node->data.var_decl.type_name && strcmp(node->data.var_decl.type_name, "void") == 0) {
             diag_error_msg(tc->diag, "E3038",

--- a/ezc/src/typechecker/types.c
+++ b/ezc/src/typechecker/types.c
@@ -336,10 +336,10 @@ EzType *type_from_name(const char *name) {
         const char *colon = strchr(start, ':');
         if (colon) {
             size_t klen = (size_t)(colon - start);
-            char *key = xmalloc(klen + 1);
-            memcpy(key, start, klen);
-            key[klen] = '\0';
-            t->key_type = key;
+            char *key_str = xmalloc(klen + 1);
+            memcpy(key_str, start, klen);
+            key_str[klen] = '\0';
+            t->key_type = key_str;
 
             const char *vstart = colon + 1;
             size_t vlen = strlen(vstart);

--- a/ezc/src/util/error_codes.h
+++ b/ezc/src/util/error_codes.h
@@ -186,6 +186,7 @@
     EZ_ERROR("E5008", "arguments", "wrong number of arguments; the function expects a different count than was provided") \
     EZ_ERROR("E5009", "arguments", "invalid base for integer conversion; base must be between 2 and 36") \
     EZ_ERROR("E5011", "usage", "return value of '%s' is not used; assign it to a variable or use '_' to discard") \
+    EZ_ERROR("E5012", "usage", "the throwaway '_' is only meaningful when discarding the result of a function call; the right-hand side has no return value to discard") \
     EZ_ERROR("E5013", "usage", "function calls are not allowed in file-scope initializers; move this declaration into a function body") \
     EZ_ERROR("E5015", "usage", "postfix ++ and -- require a variable, not a value or expression") \
     EZ_ERROR("E5023", "usage", "cannot use '%s' on type '%s'; only integer types support increment/decrement") \

--- a/ezc/src/util/error_codes.h
+++ b/ezc/src/util/error_codes.h
@@ -186,6 +186,7 @@
     EZ_ERROR("E5008", "arguments", "wrong number of arguments; the function expects a different count than was provided") \
     EZ_ERROR("E5009", "arguments", "invalid base for integer conversion; base must be between 2 and 36") \
     EZ_ERROR("E5011", "usage", "return value of '%s' is not used; assign it to a variable or use '_' to discard") \
+    EZ_ERROR("E5013", "usage", "function calls are not allowed in file-scope initializers; move this declaration into a function body") \
     EZ_ERROR("E5015", "usage", "postfix ++ and -- require a variable, not a value or expression") \
     EZ_ERROR("E5023", "usage", "cannot use '%s' on type '%s'; only integer types support increment/decrement") \
     EZ_ERROR("E5024", "usage", "return type mismatch: cannot return signed '%s' as unsigned '%s'") \

--- a/integration-tests/pass/stdlib/fmt_c.ez
+++ b/integration-tests/pass/stdlib/fmt_c.ez
@@ -145,12 +145,12 @@ do main() {
     }
 
     // eprintln doesn't crash
-    fmt.eprintln("test stderr")
+    eprintln("test stderr")
     println("  [PASS] eprintln")
     passed += 1
 
     // eprint doesn't crash
-    fmt.eprint("test no newline\n")
+    eprint("test no newline\n")
     println("  [PASS] eprint")
     passed += 1
 


### PR DESCRIPTION
## Summary

Five commits batched from `dev`:

- **`83877c59`** — accept bare `_ = expr` at statement position (closes #1647)
- **`92de338a`** — reject file-scope initializers that call functions (new diagnostic `E5013`)
- **`c6767632`** — reject throwaway `_` with a non-call RHS (new diagnostic `E5012`)
- **`51ea7afa`** — drop stale `fmt.` prefix on `eprintln`/`eprint` in the fmt_c integration test
- **`30564e90`** — map stdlib opaque types (Thread/Mutex/SpinLock/Channel/Socket/Listener/Database/Router) to their real C typedefs (closes #1645)

## New error codes

| Code | Category | Description |
|---|---|---|
| `E5012` | usage | the throwaway `_` is only meaningful when discarding the result of a function call |
| `E5013` | usage | function calls are not allowed in file-scope initializers; move the declaration into a function body |

`ERRORS.md` regenerated.