### PR TITLE
fix(typechecker): reject ref()/addr() on map index access path

### DIFF
--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -123,6 +123,10 @@ static bool is_reserved_builtin_func_name(const char *name) {
     return strcmp(name, "here") == 0;
 }
 
+/* Forward declaration — resolve_expr is defined later but needed by helper
+ * routines and stdlib arg-type validation. */
+static EzType *resolve_expr(TypeChecker *tc, AstNode *node);
+
 /* True if expr is an lvalue (something with a stable address): a variable,
  * a field of an lvalue, an index into an lvalue, or a pointer dereference.
  * Used by addr() and ref() to reject literals, call results, arithmetic
@@ -138,6 +142,26 @@ static bool is_lvalue_expr(AstNode *e) {
         return e->data.postfix.op &&
                strcmp(e->data.postfix.op, "^") == 0;
     default:                return false;
+    }
+}
+
+/* True if the access path contains a map index, e.g. ref(m["k"]) or
+ * ref(m["k"].field) or ref(rows[i].cells["k"]). Map values relocate on
+ * rehash so a pointer to one is unsafe. */
+static bool path_contains_map_index(TypeChecker *tc, AstNode *e) {
+    if (!e) return false;
+    switch (e->kind) {
+    case NODE_MEMBER_EXPR:
+        return path_contains_map_index(tc, e->data.member.object);
+    case NODE_INDEX_EXPR: {
+        EzType *left_t = resolve_expr(tc, e->data.index_expr.left);
+        if (left_t && left_t->kind == TK_MAP) return true;
+        return path_contains_map_index(tc, e->data.index_expr.left);
+    }
+    case NODE_POSTFIX_EXPR:
+        return path_contains_map_index(tc, e->data.postfix.left);
+    default:
+        return false;
     }
 }
 
@@ -596,10 +620,6 @@ static EzType *tc_get_fallible_stdlib_type(const char *mod, const char *fn) {
     }
     return NULL;
 }
-
-/* Forward declaration — resolve_expr is defined later but needed by
- * stdlib arg-type validation. */
-static EzType *resolve_expr(TypeChecker *tc, AstNode *node);
 
 /* Stdlib argument count validation table.
  * Each entry maps a (module, function) pair to the expected min/max arg count.
@@ -3290,6 +3310,11 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
                  * member/index chains so 'addr(some_call().field)' is
                  * rejected at typecheck instead of leaking an
                  * '&(rvalue)' to clang. */
+                if (path_contains_map_index(tc, arg)) {
+                    diag_error_msg(tc->diag, "E3013",
+                        "addr() cannot take the address of a map index expression; map values may relocate on rehash",
+                        NODE_FILE(tc, node), node->token.line, node->token.column, 0);
+                }
                 if (!is_lvalue_expr(arg)) {
                     diag_error_msg(tc->diag, "E3012",
                         "addr() requires a variable, field, or index expression; cannot take address of a literal or expression",
@@ -3315,6 +3340,11 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
                      * without a stable address. Without this, ref(42) and
                      * ref(some_call()) leaked '&42' / '&(rvalue)' to clang
                      * and produced opaque generated-C errors. */
+                    if (path_contains_map_index(tc, arg)) {
+                        diag_error_msg(tc->diag, "E3013",
+                            "ref() cannot take a reference to a map index expression; map values may relocate on rehash",
+                            NODE_FILE(tc, node), node->token.line, node->token.column, 0);
+                    }
                     if (!is_lvalue_expr(arg)) {
                         diag_error_msg(tc->diag, "E3012",
                             "ref() requires a variable, field, or index expression; cannot take a reference to a literal, call result, or expression",

--- a/integration-tests/fail/errors/E3013_ref_map_index.ez
+++ b/integration-tests/fail/errors/E3013_ref_map_index.ez
@@ -1,0 +1,9 @@
+/*
+ * Error Test: E3013 - ref() rejects map index expressions
+ * Expected: "map index expression"
+ */
+
+do main() {
+    mut m map[string:int] = {"a": 1}
+    mut p ^int = ref(m["a"])
+}


### PR DESCRIPTION
## Summary

Reject `ref(m[key])` and `addr(m[key])` at typecheck (E3013) instead of letting the unsafe access leak through to codegen.

## Why this matters

Issue #1654 documents a case where `ref()` accepts a map index expression that produces a dangling alias as soon as the map rehashes. The typechecker has an `is_lvalue_expr` walker (`ezc/src/typechecker/typechecker.c:130`) that recurses through index/member chains, but it does not look at the type of the indexed receiver, so map indexing is treated the same as array or struct-field indexing. Today the construct happens to fail later at the C compile step with an opaque error, which is the symptom the reporter saw.

A small `path_contains_map_index` helper next to `is_lvalue_expr` walks the same access path (MEMBER_EXPR / INDEX_EXPR / POSTFIX_EXPR) and calls `resolve_expr` on each INDEX_EXPR's left to detect a TK_MAP receiver. The `addr()` and `ref()` typecheck blocks call the helper before the existing lvalue check and emit E3013 with a clear message ("map values may relocate on rehash") instead of E3012 plus a confusing codegen failure later.

A negative test under `integration-tests/fail/errors/E3013_ref_map_index.ez` covers the exact reproducer from the issue body. `make build` and `make test-integration` pass (955/955).

## Testing

- `make build` succeeds.
- `make test-integration` passes 955/955 including the new `errors/E3013_ref_map_index` case.

Fixes #1654

AI-assisted.
