### PR TITLE
docs(stdlib): note strconv.to_float accepts inf/infinity/nan

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -2880,7 +2880,8 @@ String-to-type and type-to-string conversion functions with proper error handlin
 
 **`to_float` rules:**
 - Accepts standard decimal notation (e.g. `"3.14"`, `"-0.5"`, `"100"`).
-- Does **not** accept hex floats, infinity, or NaN strings.
+- Accepts `"inf"`, `"infinity"`, and `"nan"` (case-insensitive), returning `±Inf` / `NaN` respectively. This matches the underlying `strtod` semantics used by the implementation.
+- Does **not** accept hex floats.
 
 **`to_bool` rules:**
 - Accepts `"true"` and `"false"` (case-insensitive: `"TRUE"`, `"True"`, `"FALSE"`, etc. are valid).


### PR DESCRIPTION
## Summary

Closes #1650. The `to_float` rules in `STANDARD.md` claimed the function does not accept infinity or NaN strings, but the implementation in `ezc/src/stdlib/ez_strconv.c:69-83` calls `strtod`, which parses `"inf"`, `"infinity"`, and `"nan"` (case-insensitive) and returns the corresponding floating-point value. Updating the docs to match observed behavior - no code change.

## Why this matters

The reporter ran into the contradiction at the rules table at `STANDARD.md:2881-2883`. `ez_strconv_to_float` uses standard C `strtod`, whose acceptance set always included the inf/nan tokens. Anyone reading the spec who tried `to_float("inf")` would get a `+Inf` result back instead of the documented panic/error, which is exactly the kind of "docs say one thing, code does another" friction the issue calls out.

Hex float behavior is left as-is. `strtod` does technically parse hex floats, but the issue explicitly scoped this fix to inf / infinity / nan and didn't request a hex change. If you'd rather rejecting hex floats become a real runtime check, that's a follow-up.

## Testing

Doc-only change. No code or test touched.

Fixes #1650

AI-assisted.
