### PR TITLE
fix: type safety and big-int bug fixes

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -344,4 +344,4 @@ Runtime panics are fatal errors that terminate the program immediately. They are
 
 ---
 
-*Generated on 2026-06-02 01:10:15 UTC*
+*Generated on 2026-06-02 01:30:47 UTC*

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -3,7 +3,7 @@
 > Auto-generated from `ezc/src/util/error_codes.h`. Do not edit manually.
 > Run `./scripts/generate_errors.sh` to regenerate.
 
-**Total: 292 codes** (189 errors, 14 warnings, 89 panics)
+**Total: 293 codes** (190 errors, 14 warnings, 89 panics)
 
 ---
 
@@ -155,6 +155,7 @@
 | `E3093` | types | cannot use '%s' on '%s' |
 | `E3094` | types | cannot assign '%s' to element of '%s' |
 | `E3095` | types | 'in' only works with arrays, maps, and strings; got '%s' |
+| `E3096` | types | cannot negate unsigned type '%s'; negation of unsigned types is not defined |
 | `E4001` | names | this variable does not exist; check the spelling or make sure it is declared above this line |
 | `E4002` | names | this function does not exist; check the spelling or make sure it is defined |
 | `E4003` | names | variable '%s' already declared in this scope (line %d) |
@@ -343,4 +344,4 @@ Runtime panics are fatal errors that terminate the program immediately. They are
 
 ---
 
-*Generated on 2026-06-01 02:15:07 UTC*
+*Generated on 2026-06-02 01:10:15 UTC*

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -674,6 +674,14 @@ static const char *resolve_bigint_type(CodeGen *cg, AstNode *node) {
         if (lt) return lt;
         return resolve_bigint_type(cg, node->data.infix.right);
     }
+    /* Pointer dereference p^ — check whether the pointee type is bigint */
+    if (node->kind == NODE_POSTFIX_EXPR && strcmp(node->data.postfix.op, "^") == 0) {
+        EzType *ptr_t = cg->type_table
+            ? typetable_get(cg->type_table, node->data.postfix.left) : NULL;
+        if (ptr_t && ptr_t->kind == TK_POINTER && ptr_t->element_type &&
+            is_bigint_type(ptr_t->element_type))
+            return ptr_t->element_type;
+    }
     return NULL;
 }
 
@@ -6525,11 +6533,21 @@ static void emit_assign_statement(CodeGen *cg, AstNode *node) {
     /* Pointer dereference assignment: p^ = value → nil check + *p = value */
     if (node->data.assign.target->kind == NODE_POSTFIX_EXPR &&
         strcmp(node->data.assign.target->data.postfix.op, "^") == 0) {
+        AstNode *ptr_node = node->data.assign.target->data.postfix.left;
+        EzType *ptr_t = cg->type_table ? typetable_get(cg->type_table, ptr_node) : NULL;
+        const char *bi_elem = (ptr_t && ptr_t->kind == TK_POINTER && ptr_t->element_type &&
+                               is_bigint_type(ptr_t->element_type))
+                              ? ptr_t->element_type : NULL;
         emit(cg, "{ __auto_type _dp = ");
-        emit_expression(cg, node->data.assign.target->data.postfix.left);
+        emit_expression(cg, ptr_node);
         emit(cg, "; if (!_dp) { ez_panic_code(\"P0080\", \"nil pointer dereference\"); } *_dp");
         emitf(cg, " %s ", node->data.assign.op);
-        emit_expression(cg, node->data.assign.value);
+        if (bi_elem) {
+            emit_bigint_operand(cg, node->data.assign.value,
+                                bigint_prefix(bi_elem), bi_elem, NULL);
+        } else {
+            emit_expression(cg, node->data.assign.value);
+        }
         emit(cg, "; }\n");
         return;
     }

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -114,6 +114,21 @@ static bool is_c_keyword(const char *name) {
     return false;
 }
 
+/* Returns the bit-width rank of a sized integer type name.
+ * Higher rank = wider type. Used to pick the wider operand in
+ * mixed-width arithmetic so bounds checks fire against the right range. */
+static int int_type_rank(const char *n) {
+    if (!n) return 0;
+    if (strcmp(n, "i8")  == 0 || strcmp(n, "u8")   == 0 || strcmp(n, "byte") == 0) return 1;
+    if (strcmp(n, "i16") == 0 || strcmp(n, "u16")  == 0) return 2;
+    if (strcmp(n, "i32") == 0 || strcmp(n, "u32")  == 0) return 3;
+    if (strcmp(n, "i64") == 0 || strcmp(n, "u64")  == 0 ||
+        strcmp(n, "int") == 0 || strcmp(n, "uint") == 0) return 4;
+    if (strcmp(n, "i128") == 0 || strcmp(n, "u128") == 0) return 5;
+    if (strcmp(n, "i256") == 0 || strcmp(n, "u256") == 0) return 6;
+    return 0;
+}
+
 static const char *safe_name(const char *name) {
     if (!name || !is_c_keyword(name)) return name;
     static char bufs[4][EZ_MSG_BUF_SIZE];
@@ -1669,8 +1684,12 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
             bool is_arith = (strcmp(op, "+") == 0 || strcmp(op, "-") == 0 || strcmp(op, "*") == 0);
 
             if (is_arith && left_is_int && right_is_int && !left_is_float && !right_is_float) {
-                /* Check for sized types that need bounds-checked arithmetic */
-                const char *sized_name = (lt && lt->name) ? lt->name : ((rt && rt->name) ? rt->name : NULL);
+                /* Check for sized types that need bounds-checked arithmetic.
+                 * Pick the wider operand type so mixed-width expressions like
+                 * i8 + i16 evaluate in i16 space, not i8 space. */
+                const char *ln = (lt && lt->name) ? lt->name : NULL;
+                const char *rn = (rt && rt->name) ? rt->name : NULL;
+                const char *sized_name = (int_type_rank(rn) > int_type_rank(ln)) ? rn : (ln ? ln : rn);
                 const char *sized_min = NULL, *sized_max = NULL;
                 bool sized_unsigned = false;
                 if (sized_name) {

--- a/ezc/src/codegen/codegen.c
+++ b/ezc/src/codegen/codegen.c
@@ -677,6 +677,76 @@ static const char *resolve_bigint_type(CodeGen *cg, AstNode *node) {
     return NULL;
 }
 
+/* Emit a bigint operand, widening smaller integer or bigint operands so
+ * mixed-width expressions like i128+i64 or i256+i128 pass correctly typed
+ * values to the bigint arithmetic helpers. */
+static void emit_bigint_operand(CodeGen *cg, AstNode *operand,
+                                const char *pfx, const char *bi_type,
+                                EzType *operand_t) {
+    /* Integer literal */
+    if (operand->kind == NODE_INT_VALUE) {
+        if (operand->data.int_value.overflow) {
+            emitf(cg, "%s_from_decimal(\"%s\")", pfx, operand->data.int_value.literal);
+        } else {
+            const char *sfx = (strcmp(bi_type, "u128") == 0 || strcmp(bi_type, "u256") == 0) ? "u64" : "i64";
+            emitf(cg, "%s_from_%s(%lldLL)", pfx, sfx, (long long)operand->data.int_value.value);
+        }
+        return;
+    }
+    /* Negative integer literal */
+    if (operand->kind == NODE_PREFIX_EXPR &&
+        strcmp(operand->data.prefix.op, "-") == 0 &&
+        operand->data.prefix.right->kind == NODE_INT_VALUE) {
+        if (operand->data.prefix.right->data.int_value.overflow) {
+            emitf(cg, "%s_from_decimal(\"-%s\")", pfx,
+                  operand->data.prefix.right->data.int_value.literal);
+        } else {
+            emitf(cg, "%s_from_i64(%lldLL)", pfx,
+                  -(long long)operand->data.prefix.right->data.int_value.value);
+        }
+        return;
+    }
+    /* Check if operand is a bigint label and if it needs widening to a larger bigint */
+    if (operand->kind == NODE_LABEL) {
+        const char *src_bi = lookup_bigint_var(cg, operand->data.label.value);
+        if (src_bi) {
+            /* Operand is already a bigint — emit directly if same type,
+             * or wrap with a widening constructor for bigint→bigint promotion. */
+            if (strcmp(src_bi, bi_type) == 0) {
+                emit_expression(cg, operand);
+            } else if (strcmp(bi_type, "i256") == 0 && strcmp(src_bi, "i128") == 0) {
+                emitf(cg, "ez_i256_from_i128(");
+                emit_expression(cg, operand);
+                emit(cg, ")");
+            } else if (strcmp(bi_type, "u256") == 0 && strcmp(src_bi, "u128") == 0) {
+                emitf(cg, "ez_u256_from_u128(");
+                emit_expression(cg, operand);
+                emit(cg, ")");
+            } else {
+                /* Unknown bigint-to-bigint: emit directly and let C catch it */
+                emit_expression(cg, operand);
+            }
+            return;
+        }
+        /* Non-bigint label: widen to the target bigint type.
+         * Use operand_t kind when available; fall back to target signedness. */
+        bool target_unsigned = (strcmp(bi_type, "u128") == 0 || strcmp(bi_type, "u256") == 0);
+        bool src_unsigned = operand_t
+            ? (operand_t->kind == TK_UINT || operand_t->kind == TK_BYTE)
+            : target_unsigned;
+        if (src_unsigned) {
+            emitf(cg, "%s_from_u64((uint64_t)(", pfx);
+        } else {
+            emitf(cg, "%s_from_i64((int64_t)(", pfx);
+        }
+        emit_expression(cg, operand);
+        emit(cg, "))");
+        return;
+    }
+    /* Non-label expression — emit directly */
+    emit_expression(cg, operand);
+}
+
 static bool is_mutable_param(CodeGen *cg, const char *name) {
     if (!cg->current_func) return false;
     for (int i = 0; i < cg->current_func->data.func_decl.param_count; i++) {
@@ -1570,29 +1640,12 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
             break;
         }
 
-        /* Helper: emit an operand in bigint context, wrapping int literals */
-        #define EMIT_BIGINT_OPERAND(cg, operand, pfx, bi_type) do { \
-            if ((operand)->kind == NODE_INT_VALUE) { \
-                if ((operand)->data.int_value.overflow) { \
-                    emitf((cg), "%s_from_decimal(\"%s\")", (pfx), (operand)->data.int_value.literal); \
-                } else { \
-                    const char *_sfx = (strcmp((bi_type), "u128") == 0 || strcmp((bi_type), "u256") == 0) ? "u64" : "i64"; \
-                    emitf((cg), "%s_from_%s(%lldLL)", (pfx), _sfx, (long long)(operand)->data.int_value.value); \
-                } \
-            } else if ((operand)->kind == NODE_PREFIX_EXPR && \
-                       strcmp((operand)->data.prefix.op, "-") == 0 && \
-                       (operand)->data.prefix.right->kind == NODE_INT_VALUE) { \
-                if ((operand)->data.prefix.right->data.int_value.overflow) { \
-                    emitf((cg), "%s_from_decimal(\"-%s\")", (pfx), \
-                        (operand)->data.prefix.right->data.int_value.literal); \
-                } else { \
-                    emitf((cg), "%s_from_i64(%lldLL)", (pfx), \
-                        -(long long)(operand)->data.prefix.right->data.int_value.value); \
-                } \
-            } else { \
-                emit_expression((cg), (operand)); \
-            } \
-        } while(0)
+        /* Helper: emit an operand in bigint context.
+         * Wraps integer literals and non-bigint variables with the appropriate
+         * from_i64/from_u64 constructor so mixed-width expressions like
+         * i128 + i64 pass correctly to the bigint arithmetic helpers. */
+        #define EMIT_BIGINT_OPERAND(cg, operand, pfx, bi_type, operand_type) \
+            emit_bigint_operand((cg), (operand), (pfx), (bi_type), (operand_type))
 
         /* Bigint infix; emit function calls instead of C operators.
          * Must come before overflow-check and div-by-zero handlers since
@@ -1621,9 +1674,9 @@ static void emit_expression(CodeGen *cg, AstNode *node) {
                     } else {
                         emitf(cg, "%s_%s(", pfx, fn_op);
                     }
-                    EMIT_BIGINT_OPERAND(cg, node->data.infix.left, pfx, bi_type);
+                    EMIT_BIGINT_OPERAND(cg, node->data.infix.left, pfx, bi_type, lt);
                     emit(cg, ", ");
-                    EMIT_BIGINT_OPERAND(cg, node->data.infix.right, pfx, bi_type);
+                    EMIT_BIGINT_OPERAND(cg, node->data.infix.right, pfx, bi_type, rt);
                     if (is_checked) {
                         emitf(cg, ", __FILE__, %d)", node->token.line);
                     } else {
@@ -6261,9 +6314,9 @@ static void emit_var_declaration(CodeGen *cg, AstNode *node) {
                     emitf(cg, "%s_%s_checked(", pfx, fn_op);
                 else
                     emitf(cg, "%s_%s(", pfx, fn_op);
-                EMIT_BIGINT_OPERAND(cg, infix->data.infix.left, pfx, type_name);
+                EMIT_BIGINT_OPERAND(cg, infix->data.infix.left, pfx, type_name, NULL);
                 emit(cg, ", ");
-                EMIT_BIGINT_OPERAND(cg, infix->data.infix.right, pfx, type_name);
+                EMIT_BIGINT_OPERAND(cg, infix->data.infix.right, pfx, type_name, NULL);
                 if (is_checked)
                     emitf(cg, ", __FILE__, %d)", node->token.line);
                 else

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -1557,6 +1557,8 @@ static EzType *resolve_expr(TypeChecker *tc, AstNode *node) {
         } else if (strcmp(node->data.prefix.op, "-") == 0) {
             if (right->kind != TK_UNKNOWN && !type_is_numeric(right)) {
                 diag_error_codef(tc->diag, "E3007", NODE_FILE(tc, node), node->token.line, node->token.column, 0, type_display_name(tc, right));
+            } else if (right->kind != TK_UNKNOWN && right->name && is_unsigned_type(right->name)) {
+                diag_error_codef(tc->diag, "E3096", NODE_FILE(tc, node), node->token.line, node->token.column, 0, right->name);
             }
             result = right;
         } else if (strcmp(node->data.prefix.op, "bit_not") == 0) {

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -5997,8 +5997,12 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
                        value_type->kind != TK_VOID &&
                        declared->kind != value_type->kind &&
                        value_type->kind != TK_NIL &&
-                       /* Skip mismatch between int/uint (handled by E3019) */
-                       !(is_int_kind(declared->kind) && is_int_kind(value_type->kind)) &&
+                       /* Skip mismatch between compatible int kinds (handled by E3019),
+                        * but byte and u8/uint are distinct semantic types and must not
+                        * be implicitly assigned to each other. */
+                       !(is_int_kind(declared->kind) && is_int_kind(value_type->kind) &&
+                         !((declared->kind == TK_BYTE && value_type->kind == TK_UINT) ||
+                           (declared->kind == TK_UINT && value_type->kind == TK_BYTE))) &&
                        /* Allow enum → int (enums are int-backed) but not
                         * the reverse; int literals / variables can't be
                         * assigned to enum variables (). */
@@ -6819,7 +6823,9 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
             if (sym && sym->type->kind != TK_UNKNOWN && value_t->kind != TK_UNKNOWN &&
                 target_t->kind != TK_UNKNOWN &&
                 target_t->kind != value_t->kind &&
-                !(is_int_kind(target_t->kind) && is_int_kind(value_t->kind)) &&
+                !(is_int_kind(target_t->kind) && is_int_kind(value_t->kind) &&
+                  !((target_t->kind == TK_BYTE && value_t->kind == TK_UINT) ||
+                    (target_t->kind == TK_UINT && value_t->kind == TK_BYTE))) &&
                 !(target_t->kind == TK_ENUM && is_int_kind(value_t->kind)) &&
                 !(is_int_kind(target_t->kind) && value_t->kind == TK_ENUM) &&
                 !(target_t->kind == TK_STRUCT && is_int_kind(value_t->kind)) &&

--- a/ezc/src/util/error_codes.h
+++ b/ezc/src/util/error_codes.h
@@ -177,7 +177,8 @@
     EZ_ERROR("E3092", "types", "cannot compare '%s' to nil; only Error types and pointers can be nil") \
     EZ_ERROR("E3093", "types", "cannot use '%s' on '%s'") \
     EZ_ERROR("E3094", "types", "cannot assign '%s' to element of '%s'") \
-    EZ_ERROR("E3095", "types", "'in' only works with arrays, maps, and strings; got '%s'")
+    EZ_ERROR("E3095", "types", "'in' only works with arrays, maps, and strings; got '%s'") \
+    EZ_ERROR("E3096", "types", "cannot negate unsigned type '%s'; negation of unsigned types is not defined")
 
 /* --- E4xxx: Name Problems (References) --- */
 #define EZ_REFERENCE_ERRORS \

--- a/integration-tests/fail/errors/E3001_byte_assigned_to_u8.ez
+++ b/integration-tests/fail/errors/E3001_byte_assigned_to_u8.ez
@@ -1,0 +1,5 @@
+do main() {
+    mut b byte = 65
+    mut u u8 = b
+    println(u)
+}

--- a/integration-tests/fail/errors/E3001_byte_reassigned_from_u8.ez
+++ b/integration-tests/fail/errors/E3001_byte_reassigned_from_u8.ez
@@ -1,0 +1,6 @@
+do main() {
+    mut b byte = 10
+    mut u u8 = 20
+    b = u
+    println(b)
+}

--- a/integration-tests/fail/errors/E3001_u8_assigned_to_byte.ez
+++ b/integration-tests/fail/errors/E3001_u8_assigned_to_byte.ez
@@ -1,0 +1,5 @@
+do main() {
+    mut u u8 = 65
+    mut b byte = u
+    println(b)
+}

--- a/integration-tests/fail/errors/E3001_u8_reassigned_from_byte.ez
+++ b/integration-tests/fail/errors/E3001_u8_reassigned_from_byte.ez
@@ -1,0 +1,6 @@
+do main() {
+    mut u u8 = 10
+    mut b byte = 20
+    u = b
+    println(u)
+}

--- a/integration-tests/fail/errors/E3096_negate_byte.ez
+++ b/integration-tests/fail/errors/E3096_negate_byte.ez
@@ -1,0 +1,5 @@
+do main() {
+    mut a byte = 5
+    mut b byte = -a
+    println(b)
+}

--- a/integration-tests/fail/errors/E3096_negate_u128.ez
+++ b/integration-tests/fail/errors/E3096_negate_u128.ez
@@ -1,0 +1,5 @@
+do main() {
+    mut a u128 = 5
+    mut b u128 = -a
+    println(b)
+}

--- a/integration-tests/fail/errors/E3096_negate_u16.ez
+++ b/integration-tests/fail/errors/E3096_negate_u16.ez
@@ -1,0 +1,5 @@
+do main() {
+    mut a u16 = 5
+    mut b u16 = -a
+    println(b)
+}

--- a/integration-tests/fail/errors/E3096_negate_u256.ez
+++ b/integration-tests/fail/errors/E3096_negate_u256.ez
@@ -1,0 +1,5 @@
+do main() {
+    mut a u256 = 5
+    mut b u256 = -a
+    println(b)
+}

--- a/integration-tests/fail/errors/E3096_negate_u32.ez
+++ b/integration-tests/fail/errors/E3096_negate_u32.ez
@@ -1,0 +1,5 @@
+do main() {
+    mut a u32 = 5
+    mut b u32 = -a
+    println(b)
+}

--- a/integration-tests/fail/errors/E3096_negate_u64.ez
+++ b/integration-tests/fail/errors/E3096_negate_u64.ez
@@ -1,0 +1,5 @@
+do main() {
+    mut a u64 = 5
+    mut b u64 = -a
+    println(b)
+}

--- a/integration-tests/fail/errors/E3096_negate_u8.ez
+++ b/integration-tests/fail/errors/E3096_negate_u8.ez
@@ -1,0 +1,5 @@
+do main() {
+    mut a u8 = 5
+    mut b u8 = -a
+    println(b)
+}

--- a/integration-tests/fail/errors/E3096_negate_uint.ez
+++ b/integration-tests/fail/errors/E3096_negate_uint.ez
@@ -1,0 +1,5 @@
+do main() {
+    mut a uint = 5
+    mut b uint = -a
+    println(b)
+}

--- a/integration-tests/fail/errors/panic_mixed_width_overflow_i16.ez
+++ b/integration-tests/fail/errors/panic_mixed_width_overflow_i16.ez
@@ -1,0 +1,7 @@
+// i8 + i16 where result overflows i16 — should panic at i16 boundary, not i8
+do main() {
+    mut a i8 = 100
+    mut b i16 = 32700
+    mut c i16 = a + b
+    println(c)
+}

--- a/integration-tests/pass/core/bigint_mixed_width_arithmetic.ez
+++ b/integration-tests/pass/core/bigint_mixed_width_arithmetic.ez
@@ -1,0 +1,96 @@
+do main() {
+    println("=== Big-Int Mixed-Width Arithmetic ===")
+    mut passed int = 0
+    mut failed int = 0
+
+    // i128 + i64
+    mut a i128 = 100
+    mut b i64 = 50
+    mut c i128 = a + b
+    if c == 150 {
+        println("  [PASS] i128(100) + i64(50) = 150")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i128 + i64")
+        failed += 1
+    }
+
+    // i128 - i32
+    mut d i128 = 200
+    mut e i32 = 75
+    mut f i128 = d - e
+    if f == 125 {
+        println("  [PASS] i128(200) - i32(75) = 125")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i128 - i32")
+        failed += 1
+    }
+
+    // i128 * i64
+    mut g i128 = 10
+    mut h i64 = 15
+    mut ii i128 = g * h
+    if ii == 150 {
+        println("  [PASS] i128(10) * i64(15) = 150")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i128 * i64")
+        failed += 1
+    }
+
+    // u128 + u64
+    mut j u128 = 100
+    mut k u64 = 50
+    mut l u128 = j + k
+    if l == 150 {
+        println("  [PASS] u128(100) + u64(50) = 150")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] u128 + u64")
+        failed += 1
+    }
+
+    // i256 + i128
+    mut m i256 = 100
+    mut n i128 = 50
+    mut o i256 = m + n
+    if o == 150 {
+        println("  [PASS] i256(100) + i128(50) = 150")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i256 + i128")
+        failed += 1
+    }
+
+    // u256 + u128
+    mut p u256 = 100
+    mut q u128 = 50
+    mut r u256 = p + q
+    if r == 150 {
+        println("  [PASS] u256(100) + u128(50) = 150")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] u256 + u128")
+        failed += 1
+    }
+
+    // i128 == i64 comparison
+    mut s i128 = 42
+    mut t i64 = 42
+    if s == t {
+        println("  [PASS] i128(42) == i64(42)")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i128 == i64 comparison")
+        failed += 1
+    }
+
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/integration-tests/pass/core/bigint_pointer_deref.ez
+++ b/integration-tests/pass/core/bigint_pointer_deref.ez
@@ -1,0 +1,98 @@
+do main() {
+    println("=== Big-Int Pointer Dereference ===")
+    mut passed int = 0
+    mut failed int = 0
+
+    // ^i128 read
+    mut a i128 = 42
+    mut pa ^i128 = addr(a)
+    if pa^ == 42 {
+        println("  [PASS] ^i128 dereference read")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] ^i128 dereference read")
+        failed += 1
+    }
+
+    // ^i128 write
+    pa^ = 999
+    if a == 999 {
+        println("  [PASS] ^i128 dereference write")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] ^i128 dereference write")
+        failed += 1
+    }
+
+    // ^u128 read
+    mut b u128 = 100
+    mut pb ^u128 = addr(b)
+    if pb^ == 100 {
+        println("  [PASS] ^u128 dereference read")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] ^u128 dereference read")
+        failed += 1
+    }
+
+    // ^u128 write
+    pb^ = 777
+    if b == 777 {
+        println("  [PASS] ^u128 dereference write")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] ^u128 dereference write")
+        failed += 1
+    }
+
+    // ^i256 read and write
+    mut c i256 = 200
+    mut pc ^i256 = addr(c)
+    if pc^ == 200 {
+        println("  [PASS] ^i256 dereference read")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] ^i256 dereference read")
+        failed += 1
+    }
+    pc^ = 555
+    if c == 555 {
+        println("  [PASS] ^i256 dereference write")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] ^i256 dereference write")
+        failed += 1
+    }
+
+    // ^u256 read and write
+    mut d u256 = 300
+    mut pd ^u256 = addr(d)
+    if pd^ == 300 {
+        println("  [PASS] ^u256 dereference read")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] ^u256 dereference read")
+        failed += 1
+    }
+    pd^ = 111
+    if d == 111 {
+        println("  [PASS] ^u256 dereference write")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] ^u256 dereference write")
+        failed += 1
+    }
+
+    // println of dereferenced bigint pointer
+    mut e i128 = 12345
+    mut pe ^i128 = addr(e)
+    println(pe^)
+
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/integration-tests/pass/core/mixed_width_arithmetic.ez
+++ b/integration-tests/pass/core/mixed_width_arithmetic.ez
@@ -1,0 +1,85 @@
+do main() {
+    println("=== Mixed-Width Integer Arithmetic ===")
+    mut passed int = 0
+    mut failed int = 0
+
+    // i8 + i16 — should widen to i16
+    mut a i8 = 100
+    mut b i16 = 100
+    mut c i16 = a + b
+    if c == 200 {
+        println("  [PASS] i8(100) + i16(100) = 200")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i8(100) + i16(100)")
+        failed += 1
+    }
+
+    // i8 + i16 at i8 boundary — widens so no panic
+    mut d i8 = 127
+    mut e i16 = 1
+    mut f i16 = d + e
+    if f == 128 {
+        println("  [PASS] i8(127) + i16(1) = 128")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i8(127) + i16(1)")
+        failed += 1
+    }
+
+    // u8 + u16 — should widen to u16
+    mut g u8 = 200
+    mut h u16 = 200
+    mut ii u16 = g + h
+    if ii == 400 {
+        println("  [PASS] u8(200) + u16(200) = 400")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] u8(200) + u16(200)")
+        failed += 1
+    }
+
+    // i16 - i8 — should widen to i16
+    mut j i16 = 1000
+    mut k i8 = 100
+    mut l i16 = j - k
+    if l == 900 {
+        println("  [PASS] i16(1000) - i8(100) = 900")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i16(1000) - i8(100)")
+        failed += 1
+    }
+
+    // i8 * i16 — should widen to i16
+    mut m i8 = 10
+    mut n i16 = 200
+    mut o i16 = m * n
+    if o == 2000 {
+        println("  [PASS] i8(10) * i16(200) = 2000")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i8(10) * i16(200)")
+        failed += 1
+    }
+
+    // i8 + i32 — should widen to i32
+    mut p i8 = 100
+    mut q i32 = 2000000
+    mut r i32 = p + q
+    if r == 2000100 {
+        println("  [PASS] i8(100) + i32(2000000) = 2000100")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] i8(100) + i32(2000000)")
+        failed += 1
+    }
+
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/integration-tests/pass/core/negate_signed_types.ez
+++ b/integration-tests/pass/core/negate_signed_types.ez
@@ -1,0 +1,37 @@
+do main() {
+    mut a i8 = 10
+    mut b i8 = -a
+    println(b)
+
+    mut c i16 = 1000
+    mut d i16 = -c
+    println(d)
+
+    mut e i32 = 100000
+    mut f i32 = -e
+    println(f)
+
+    mut g i64 = 9999999
+    mut h i64 = -g
+    println(h)
+
+    mut ii int = 42
+    mut j int = -ii
+    println(j)
+
+    mut k i128 = 123456789
+    mut l i128 = -k
+    println(l)
+
+    mut m float = 3.14
+    mut n float = -m
+    println(n)
+
+    mut o f32 = 1.5
+    mut p f32 = -o
+    println(p)
+
+    mut q f64 = 2.71
+    mut r f64 = -q
+    println(r)
+}


### PR DESCRIPTION
## Summary

- Reject negation of unsigned integer types at compile time (E3096) — `u8`, `u16`, `u32`, `u64`, `u128`, `u256`, `uint`, `byte` — closes #1757, #1760
- Widen mixed-width integer arithmetic to the larger operand's domain so `i8(100) + i16(100)` correctly yields `200` — closes #1756
- Reject implicit `byte`↔`u8` assignment in both var-decl and reassignment paths — closes #1752
- Widen smaller integer operands in big-int arithmetic (`i128 + i64`, `i256 + i128`, etc.) — closes #1758
- Handle big-int pointer dereference in `println` and deref-assign (`^i128`, `^u128`, `^i256`, `^u256`) — closes #1761