### PR TITLE
fix: type system improvements and struct field validation

### DIFF
--- a/ezc/src/parser/parser.c
+++ b/ezc/src/parser/parser.c
@@ -1615,7 +1615,7 @@ static AstNode *parse_func_declaration(Parser *p) {
         if (!p_i->type_name && i + 1 < node->data.func_decl.param_count) {
             p_i->type_name = node->data.func_decl.params[i + 1].type_name;
         }
-        if (!p_i->type_name) {
+        if (!p_i->type_name && !p_i->default_value) {
             char buf[EZ_MSG_BUF_SIZE];
             snprintf(buf, sizeof(buf),
                 "parameter '%s' is missing a type; every parameter must have a type (e.g., %s int)",

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -7687,6 +7687,21 @@ static void check_statement(TypeChecker *tc, AstNode *node) {
                 diag_error_msg(tc->diag, "E4016", strdup(msg),
                     NODE_FILE(tc, node), node->token.line, node->token.column, 0);
             }
+            /* Type inference: if no explicit type annotation, infer from default
+             * value when it is an enum member access (e.g. t = Color.RED). */
+            if (!p->type_name && p->default_value) {
+                EzType *inferred = resolve_expr(tc, p->default_value);
+                if (inferred && inferred->kind == TK_ENUM) {
+                    ptype = inferred;
+                } else {
+                    char msg[EZ_MSG_BUF_SIZE];
+                    snprintf(msg, sizeof(msg),
+                        "parameter '%s' has no type annotation; omitting the type is only allowed when the default value is an enum member (e.g. %s = MyEnum.VALUE)",
+                        p->name, p->name);
+                    diag_error_msg(tc->diag, "E2002", strdup(msg),
+                        NODE_FILE(tc, node), node->token.line, node->token.column, 0);
+                }
+            }
             /* E3001: validate default value type matches parameter type */
             if (p->default_value && p->type_name) {
                 EzType *def_t = resolve_expr(tc, p->default_value);

--- a/ezc/src/typechecker/typechecker.c
+++ b/ezc/src/typechecker/typechecker.c
@@ -8200,6 +8200,83 @@ static bool struct_contains_by_value(AstNode *program, AstNode *decl,
     return false;
 }
 
+/* Recursively validate that every named type inside a field's type string
+ * (including array element types, map key/value types, pointer pointees, and
+ * arbitrarily nested combinations) refers to a known type. Emits E4016 for
+ * every unknown leaf type found. */
+static void validate_field_type_recursive(TypeChecker *tc, AstNode *program,
+                                          const char *type_name,
+                                          const char *field_name,
+                                          AstNode *stmt) {
+    if (!type_name || !*type_name) return;
+
+    /* Pointer: ^T → recurse on T */
+    if (type_name[0] == '^') {
+        const char *pointee = type_name + 1;
+        while (*pointee == '^') pointee++;
+        validate_field_type_recursive(tc, program, pointee, field_name, stmt);
+        return;
+    }
+
+    /* Array: [T] or [T,N] → recurse on T */
+    if (type_name[0] == '[') {
+        size_t len = strlen(type_name);
+        if (len > 2 && type_name[len - 1] == ']') {
+            char elem[EZ_MSG_BUF_SIZE];
+            size_t elem_len = len - 2;
+            memcpy(elem, type_name + 1, elem_len);
+            elem[elem_len] = '\0';
+            char *comma = strchr(elem, ',');
+            if (comma) *comma = '\0';
+            validate_field_type_recursive(tc, program, elem, field_name, stmt);
+        }
+        return;
+    }
+
+    /* Map: map[K:V] → recurse on K and V separately */
+    if (strncmp(type_name, "map[", 4) == 0) {
+        size_t len = strlen(type_name);
+        if (len > 5 && type_name[len - 1] == ']') {
+            /* Extract inner "K:V" string */
+            char inner[EZ_MSG_BUF_SIZE];
+            size_t inner_len = len - 5; /* skip "map[" and "]" */
+            memcpy(inner, type_name + 4, inner_len);
+            inner[inner_len] = '\0';
+            /* Find colon at depth 0 (handles nested [T] keys) */
+            int depth = 0;
+            int colon_pos = -1;
+            for (int i = 0; inner[i]; i++) {
+                if (inner[i] == '[') depth++;
+                else if (inner[i] == ']') depth--;
+                else if (inner[i] == ':' && depth == 0) { colon_pos = i; break; }
+            }
+            if (colon_pos >= 0) {
+                char key_t[EZ_MSG_BUF_SIZE];
+                memcpy(key_t, inner, (size_t)colon_pos);
+                key_t[colon_pos] = '\0';
+                const char *val_t = inner + colon_pos + 1;
+                validate_field_type_recursive(tc, program, key_t, field_name, stmt);
+                validate_field_type_recursive(tc, program, val_t, field_name, stmt);
+            }
+        }
+        return;
+    }
+
+    /* Leaf: must be a known primitive, enum, or struct */
+    EzType *t = tc_type_from_name(tc, type_name);
+    if (t && t->kind != TK_STRUCT && t->kind != TK_UNKNOWN) return;
+    if (is_enum_name(tc, type_name)) return;
+    if (is_struct_name(tc, type_name)) return;
+    if (struct_name_declared(program, type_name)) return;
+
+    char msg[EZ_MSG_BUF_SIZE];
+    snprintf(msg, sizeof(msg),
+        "field '%s' references undefined type '%s'",
+        field_name, type_name);
+    diag_error_msg(tc->diag, "E4016", strdup(msg),
+        NODE_FILE(tc, stmt), stmt->token.line, stmt->token.column, 0);
+}
+
 static void register_declarations(TypeChecker *tc, AstNode *program) {
     tc->registering = true;
     /* Validate and record imports */
@@ -8397,29 +8474,10 @@ static void register_declarations(TypeChecker *tc, AstNode *program) {
                             NODE_FILE(tc, stmt), stmt->token.line, stmt->token.column, 0);
                     }
                 }
-                /* Pointer field pointee validation: ^T where T must be a
-                 * known primitive, registered enum/struct, or a struct
-                 * declared anywhere in the program (handles self-recursion
-                 * and forward references where the struct isn't yet
-                 * registered). */
-                if (ftn && *ftn && ftn[0] == '^') {
-                    const char *pointee = ftn + 1;
-                    while (*pointee == '^') pointee++;
-                    bool known = false;
-                    EzType *pt = tc_type_from_name(tc, pointee);
-                    if (pt && pt->kind != TK_STRUCT) known = true;
-                    if (!known && is_enum_name(tc, pointee)) known = true;
-                    if (!known && is_struct_name(tc, pointee)) known = true;
-                    if (!known && struct_name_declared(program, pointee)) known = true;
-                    if (!known) {
-                        char msg[EZ_MSG_BUF_SIZE];
-                        snprintf(msg, sizeof(msg),
-                            "pointer field '%s' references undefined type '%s'",
-                            fnames[j], pointee);
-                        diag_error_msg(tc->diag, "E4016", strdup(msg),
-                            NODE_FILE(tc, stmt), stmt->token.line, stmt->token.column, 0);
-                    }
-                }
+                /* Validate all named types within the field type recursively.
+                 * Covers ^T, [T], map[K:V], and arbitrary nesting thereof. */
+                if (ftn && *ftn)
+                    validate_field_type_recursive(tc, program, ftn, fnames[j], stmt);
                 /* Check for duplicate field names */
                 for (int k = 0; k < j; k++) {
                     if (strcmp(fnames[k], fnames[j]) == 0) {

--- a/ezc/src/typechecker/types.c
+++ b/ezc/src/typechecker/types.c
@@ -24,7 +24,7 @@ EzType TYPE_STRING  = {TK_STRING, "string", NULL, NULL, NULL, NULL};
 EzType TYPE_NIL     = {TK_NIL,    "nil",    NULL, NULL, NULL, NULL};
 EzType TYPE_UNKNOWN = {TK_UNKNOWN,"unknown",NULL, NULL, NULL, NULL};
 
-#define TYPE_POOL_CAPACITY 1024
+#define TYPE_POOL_CAPACITY 4096
 
 /* Pool for dynamically created types (leak on exit, fine for a compiler) */
 static EzType type_pool[TYPE_POOL_CAPACITY];
@@ -38,7 +38,20 @@ EzType *type_alloc(void) {
     return &type_pool[type_pool_count++];
 }
 
+/* Return an existing pool entry matching kind+name, or NULL if not found. */
+static EzType *pool_find(TypeKind kind, const char *name) {
+    if (!name) return NULL;
+    for (int i = 0; i < type_pool_count; i++) {
+        EzType *t = &type_pool[i];
+        if (t->kind == kind && t->name && strcmp(t->name, name) == 0)
+            return t;
+    }
+    return NULL;
+}
+
 EzType *type_array(const char *elem_type) {
+    EzType *existing = pool_find(TK_ARRAY, elem_type);
+    if (existing) return existing;
     EzType *t = type_alloc();
     t->kind = TK_ARRAY;
     t->element_type = elem_type;
@@ -47,6 +60,8 @@ EzType *type_array(const char *elem_type) {
 }
 
 EzType *type_struct(const char *name) {
+    EzType *existing = pool_find(TK_STRUCT, name);
+    if (existing) return existing;
     EzType *t = type_alloc();
     t->kind = TK_STRUCT;
     t->name = strdup(name);
@@ -54,6 +69,8 @@ EzType *type_struct(const char *name) {
 }
 
 EzType *type_enum(const char *name) {
+    EzType *existing = pool_find(TK_ENUM, name);
+    if (existing) return existing;
     EzType *t = type_alloc();
     t->kind = TK_ENUM;
     t->name = strdup(name);
@@ -61,6 +78,8 @@ EzType *type_enum(const char *name) {
 }
 
 EzType *type_pointer(const char *pointee_type) {
+    EzType *existing = pool_find(TK_POINTER, pointee_type);
+    if (existing) return existing;
     EzType *t = type_alloc();
     t->kind = TK_POINTER;
     const char *dup = strdup(pointee_type);
@@ -292,6 +311,8 @@ EzType *type_from_name(const char *name) {
     /* Typed function reference: "func(p1,&p2)->R" — checked before bsearch
      * so "func(...)" doesn't get conflated with the bare "func" entry. */
     if (strncmp(name, "func(", 5) == 0) {
+        EzType *existing = pool_find(TK_FUNCTION, name);
+        if (existing) return existing;
         EzType *t = type_alloc();
         t->kind = TK_FUNCTION;
         t->name = strdup(name);
@@ -304,6 +325,9 @@ EzType *type_from_name(const char *name) {
                                     sizeof(BuiltinTypeEntry), builtin_type_cmp);
     if (hit) {
         if (hit->singleton) return hit->singleton;
+        const char *resolved_name = hit->alloc_name ? hit->alloc_name : name;
+        EzType *existing = pool_find(hit->alloc_kind, resolved_name);
+        if (existing) return existing;
         EzType *t = type_alloc();
         t->kind = hit->alloc_kind;
         t->name = hit->alloc_name ? hit->alloc_name : strdup(name);
@@ -331,9 +355,11 @@ EzType *type_from_name(const char *name) {
 
     /* Map type: map[K:V] */
     if (strncmp(name, "map[", 4) == 0) {
+        EzType *existing = pool_find(TK_MAP, name);
+        if (existing) return existing;
         EzType *t = type_alloc();
         t->kind = TK_MAP;
-        t->name = name;
+        t->name = strdup(name);
         /* Parse key:value types from "map[string:int]" */
         const char *start = name + 4;
         const char *colon = strchr(start, ':');

--- a/integration-tests/pass/core/default_param_enum_inference.ez
+++ b/integration-tests/pass/core/default_param_enum_inference.ez
@@ -1,0 +1,90 @@
+/*
+ * default_param_enum_inference.ez
+ * Test that parameter type can be omitted when default value is an enum member.
+ */
+
+const Direction enum {
+    NORTH = 0,
+    SOUTH,
+    EAST,
+    WEST
+}
+
+const Priority enum {
+    LOW = 1,
+    MEDIUM,
+    HIGH
+}
+
+// Type omitted — inferred as Direction from default
+do move(dir = Direction.NORTH) -> int {
+    when dir {
+        is Direction.NORTH { return 1 }
+        is Direction.SOUTH { return 2 }
+        is Direction.EAST  { return 3 }
+        is Direction.WEST  { return 4 }
+        default            { return 0 }
+    }
+}
+
+// Mixed: explicit type for first param, inferred for second
+do task(name string, p = Priority.MEDIUM) -> int {
+    when p {
+        is Priority.LOW    { return 1 }
+        is Priority.MEDIUM { return 2 }
+        is Priority.HIGH   { return 3 }
+        default            { return 0 }
+    }
+}
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    // Test 1: call with no args, uses default Direction.NORTH
+    mut r1 = move()
+    if r1 == 1 {
+        println("  [PASS] move() uses default Direction.NORTH")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] move(): expected 1, got ${r1}")
+        failed += 1
+    }
+
+    // Test 2: call with explicit enum value
+    mut r2 = move(Direction.WEST)
+    if r2 == 4 {
+        println("  [PASS] move(Direction.WEST) returns 4")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] move(Direction.WEST): expected 4, got ${r2}")
+        failed += 1
+    }
+
+    // Test 3: mixed params, default priority
+    mut r3 = task("build")
+    if r3 == 2 {
+        println("  [PASS] task('build') uses default Priority.MEDIUM")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] task('build'): expected 2, got ${r3}")
+        failed += 1
+    }
+
+    // Test 4: mixed params, explicit priority
+    mut r4 = task("deploy", Priority.HIGH)
+    if r4 == 3 {
+        println("  [PASS] task('deploy', Priority.HIGH) returns 3")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] task('deploy', Priority.HIGH): expected 3, got ${r4}")
+        failed += 1
+    }
+
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}


### PR DESCRIPTION
## Summary

- **Type pool exhaustion fix**: Added interning (`pool_find`) to prevent duplicate pool entries for identical types. Raised cap from 1024 → 4096 as a safety buffer pending full refactor (#1770)
- **Undefined types in struct fields**: Recursive validation of all named types in struct field annotations — catches misspelled/undefined types in arrays (`[Clusters]`), maps (`map[Barz:string]`), pointers (`^Barz`), and arbitrary nesting thereof. Emits E4016 instead of leaking C compiler errors
- **Enum default parameter inference**: Parameters with enum member defaults no longer require a redundant type annotation. `do foo(t = Color.RED)` infers `t: Color` automatically. Non-enum omissions still error with a clear message