### PR TITLE
Bugfixes & refactors batch August 8, 2026

### DIFF
--- a/ERRORS.md
+++ b/ERRORS.md
@@ -1,7 +1,7 @@
 # Grayscale Error Code Reference
 
 > Auto-generated from `grayc/src/util/error_codes.h`. Do not edit manually.
-> Run `./scripts/generate_errors.sh` to regenerate.
+> Run `./scripts/generate_errors.gray` to regenerate.
 
 **Total: 378 codes** (258 errors, 17 warnings, 103 panics)
 
@@ -429,4 +429,4 @@ Runtime panics are fatal errors that terminate the program immediately. They are
 
 ---
 
-*Generated on 2026-08-07 23:15:10 UTC*
+*Generated on 2026-08-08 11:00:39 UTC*

--- a/ERRORS.md
+++ b/ERRORS.md
@@ -3,7 +3,7 @@
 > Auto-generated from `grayc/src/util/error_codes.h`. Do not edit manually.
 > Run `./scripts/generate_errors.sh` to regenerate.
 
-**Total: 377 codes** (257 errors, 17 warnings, 103 panics)
+**Total: 378 codes** (258 errors, 17 warnings, 103 panics)
 
 ---
 
@@ -249,6 +249,7 @@
 | `E5038` | usage | tagged enum '%s' cannot be passed to %s(); use when/is to destructure the payload first |
 | `E5039` | usage | constant expression overflows type '%s' |
 | `E5040` | usage | constant requires a compile-time value; function calls are evaluated at runtime |
+| `E5041` | usage | tagged enum '%s' cannot be used as a map value type; use when/is to destructure before storing |
 | `E6001` | imports | unknown module '@%s' |
 | `E6002` | imports | cannot find file or directory '%s' |
 | `E6003` | imports | directory '%s' contains no .gray files |
@@ -428,4 +429,4 @@ Runtime panics are fatal errors that terminate the program immediately. They are
 
 ---
 
-*Generated on 2026-08-02 03:39:48 UTC*
+*Generated on 2026-08-07 23:15:10 UTC*

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -336,7 +336,23 @@ mut c byte = 128   // decimal also works
 
 Assigning a value outside the range 0-255 to a `byte` is a check-time error.
 
-#### 3.1.8 Sized Integer Types
+#### 3.1.8 Sized Floating-Point Types
+
+Grayscale provides fixed-width floating-point types:
+
+| Type | Width | C Type | Precision |
+|------|-------|--------|-----------|
+| `f32` | 32-bit | `float` | ~7 decimal digits (IEEE 754 single-precision) |
+| `f64` | 64-bit | `double` | ~15 decimal digits (IEEE 754 double-precision) |
+
+`f64` is equivalent to `float`. Use `f32` when interfacing with C APIs that expect single-precision or when memory is constrained.
+
+```gray
+mut x f32 = 3.14    // single-precision
+mut y f64 = 3.14    // double-precision (same as float)
+```
+
+#### 3.1.9 Sized Integer Types
 
 Grayscale provides fixed-width integer types for precise control over integer size:
 
@@ -353,7 +369,7 @@ Grayscale provides fixed-width integer types for precise control over integer si
 
 Use `cast` for sized type conversions: `cast(value, i32)`, `cast(value, u16)`.
 
-#### 3.1.9 Wide Integer Types (`i128`, `u128`, `i256`, `u256`)
+#### 3.1.10 Wide Integer Types (`i128`, `u128`, `i256`, `u256`)
 
 Grayscale provides portable wide integer types backed by struct-based arithmetic (no compiler extensions required):
 
@@ -539,7 +555,7 @@ const Node struct {
 // Value-type self-reference is an error:
 const Bad struct {
     val  int
-    next Bad     // error: struct 'Bad' cannot contain itself by value; use ptr<Bad>
+    next Bad     // error: struct 'Bad' cannot contain itself by value; use a pointer field '^Bad'
 }
 ```
 
@@ -620,7 +636,7 @@ const Direction enum {
 
 > 💡 **Tip:** Enum variants must be on separate lines. Inline declarations like `const Color enum { RED; GREEN; BLUE }` are not allowed. Semicolons are never used in enum declarations.
 
-> 💡 **Tip:** Enums are not integers. Even though integer enums are backed by numeric values under the hood, you cannot compare an enum variable with an integer (`d == 0`), assign an integer to an enum variable (`d = 2`), or perform arithmetic on enum values. Enums can only be compared with values of the same enum type using `==` and `!=`. Use `Direction.NORTH`, `.NORTH`, or another `Direction` variable — never a raw number.
+> 💡 **Tip:** Enums are not integers. Even though integer enums are backed by numeric values under the hood, you cannot compare an enum variable with an integer (`d == 0`), assign an integer to an enum variable (`d = 2`), or perform arithmetic on enum values. Enums can only be compared with values of the same enum type using `==` and `!=`. Use `Direction.NORTH`, `.NORTH`, or another `Direction` variable — never a raw number. However, assigning an enum value to an `int` variable is allowed — the enum is implicitly widened to its underlying integer value: `mut status int = Direction.NORTH` assigns `0`.
 
 > 💡 **Tip:** If you genuinely need to compare an enum value against an integer, use `cast()` to bridge the gap: `if cast(Direction.NORTH, int) == 0 { ... }`. You can also cast the other way: `cast(0, Direction)`.
 
@@ -1523,11 +1539,25 @@ do double(x int) -> int {
 
 #### 7.2.2 Mutable Parameters
 
-Mutable parameters work with:
-- Primitive types
-- Struct fields: `increment(point.x)`
-- Array elements: `increment(arr[0])`
-- Map values: `increment(map["key"])`
+The `&` prefix on a parameter name declares it as mutable (pass-by-reference). The function can modify the caller's variable through the parameter:
+
+```gray
+do increment(&x int) {
+    x = x + 1
+}
+
+do main() {
+    mut val int = 5
+    increment(val)    // no & at the call site
+    println(val)      // 6
+}
+```
+
+**Rules:**
+- `&` goes before the parameter name in the function signature: `do f(&x int)`.
+- At the call site, pass the variable directly — no `&` prefix: `f(val)`.
+- Only `mut` variables can be passed to `&` parameters. Passing a `const` variable is a compile-time error (E3027).
+- `&` parameters also accept struct fields (`increment(point.x)`), array elements (`increment(arr[0])`), and map values (`increment(map["key"])`).
 
 #### 7.2.3 Grouped Parameters
 
@@ -2522,8 +2552,8 @@ All types are printable: `string`, `int`, `float`, `bool`, arrays, maps, structs
 | `type_of` | `(value T) -> string` | Returns the Grayscale type name as a string (e.g. `"int"`, `"uint"`, `"float"`, `"string"`, `"i128"`, `"u256"`). Accepts any type. |
 | `size_of` | `(Type) -> int` | Size of type in bytes |
 | `copy` | `(value T) -> T` | Create deep copy. Accepts any type. |
-| `new` | `(Type) -> ^Type` | Allocate zero-initialized struct on arena |
-| `ref` | `(variable T) -> ref<T>` | Create a transparent reference (alias) to a variable. Reads and writes through the reference affect the original. Mutability is determined by the declaration (`mut` or `const`). |
+| `new` | `(Type) -> ^Type` | Allocate zero-initialized value of any type on the heap arena |
+| `ref` | `(variable T) -> T` | Create a transparent reference (alias) to a variable. The return type is inferred and cannot be explicitly annotated. Reads and writes through the reference affect the original. Mutability is determined by the declaration (`mut` or `const`). |
 | `addr` | `(variable) -> ^T` | Get memory address of a variable |
 | `error` | `(message string) -> Error` | Create error value |
 | `assert` | `(condition bool [, message string])` | Terminate with `P0075` if condition is false. Message is optional. |
@@ -3436,11 +3466,13 @@ Message passing between threads. Compiler-only feature; requires POSIX threads.
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `open` | `(capacity int) -> Channel` | Create a buffered channel |
-| `send` | `(ch Channel, value)` | Send a value into a channel |
-| `receive` | `(ch Channel) -> T` | Receive a value from a channel |
+| `send` | `(ch Channel, value int)` | Send an int value into a channel |
+| `receive` | `(ch Channel) -> int` | Receive an int value from a channel (blocks if empty) |
 | `close` | `(ch Channel)` | Close a channel |
 | `try_send` | `(ch Channel, value int) -> bool` | Non-blocking send; returns false if full |
 | `try_receive` | `(ch Channel) -> (int, bool)` | Non-blocking receive; returns value and success |
+
+Channels are **int-only**. Sending non-int types (`string`, `float`, `bool`, etc.) is a compile-time error.
 
 ### 9.25 Memory Module (`@mem`)
 

--- a/cli/main.go
+++ b/cli/main.go
@@ -38,6 +38,7 @@ func main() {
 		if errors.As(err, &exitErr) {
 			os.Exit(exitErr.Code)
 		}
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -4863,7 +4863,8 @@ static bool emit_json_call(CodeGen *codegen, AstNode *node, const char *func) {
 
 static bool emit_sqlite_call(CodeGen *codegen, AstNode *node, const char *func) {
     bool is_fallible = (strcmp(func, "open") == 0 || strcmp(func, "exec") == 0 ||
-        strcmp(func, "query") == 0);
+        strcmp(func, "query") == 0 || strcmp(func, "exec_params") == 0 ||
+        strcmp(func, "query_params") == 0);
     bool is_multi_var = is_result_temporary(codegen->current_var_name);
     if (strcmp(func, "open") == 0) {
         emit_formatted(codegen, "gray_sqlite_open%s(gray_default_arena, ", (is_fallible && is_multi_var) ? "_result" : "");
@@ -4889,11 +4890,35 @@ static bool emit_sqlite_call(CodeGen *codegen, AstNode *node, const char *func) 
         emit(codegen, ")");
         return true;
     }
+    if (strcmp(func, "exec_params") == 0) {
+        if (is_multi_var) {
+            emit(codegen, "gray_sqlite_exec_params_result(gray_default_arena, ");
+        } else {
+            emit(codegen, "gray_sqlite_exec_params(");
+        }
+        emit_expression(codegen, node->data.call.args[0]);
+        emit(codegen, ", ");
+        emit_expression(codegen, node->data.call.args[1]);
+        emit(codegen, ", ");
+        emit_expression(codegen, node->data.call.args[2]);
+        emit(codegen, ")");
+        return true;
+    }
     if (strcmp(func, "query") == 0) {
         emit_formatted(codegen, "gray_sqlite_query%s(gray_default_arena, ", is_multi_var ? "_result" : "");
         emit_expression(codegen, node->data.call.args[0]);
         emit(codegen, ", ");
         emit_expression(codegen, node->data.call.args[1]);
+        emit(codegen, ")");
+        return true;
+    }
+    if (strcmp(func, "query_params") == 0) {
+        emit_formatted(codegen, "gray_sqlite_query_params%s(gray_default_arena, ", is_multi_var ? "_result" : "");
+        emit_expression(codegen, node->data.call.args[0]);
+        emit(codegen, ", ");
+        emit_expression(codegen, node->data.call.args[1]);
+        emit(codegen, ", ");
+        emit_expression(codegen, node->data.call.args[2]);
         emit(codegen, ")");
         return true;
     }
@@ -6101,7 +6126,7 @@ static void emit_call_expression(CodeGen *codegen, AstNode *node) {
                 {"parse","csv"},{"read_file","csv"},{"headers","csv"},
                 {"write_file","csv"},{"format","csv"},{"encode","csv"},
                 /* @sqlite */
-                {"open","sqlite"},{"close","sqlite"},{"exec","sqlite"},{"query","sqlite"},
+                {"open","sqlite"},{"close","sqlite"},{"exec","sqlite"},{"exec_params","sqlite"},{"query","sqlite"},{"query_params","sqlite"},
                 /* @threads */
                 {"spawn","threads"},{"join","threads"},{"get_id","threads"},
                 {"detach","threads"},{"is_alive","threads"},{"current","threads"},

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -5054,6 +5054,9 @@ static bool emit_arrays_call(CodeGen *codegen, AstNode *node, const char *func) 
             if (val_t->kind == TK_STRUCT) {
                 c_elem = gray_type_to_c_codegen(codegen, val_t->name);
             }
+            if (val_t->kind == TK_ENUM) {
+                c_elem = gray_type_to_c_codegen(codegen, val_t->name);
+            }
             if (val_t->kind == TK_POINTER && val_t->name) {
                 /* val_t->name is the pointee (e.g. "int"); prepend ^ for gray_type_to_c_codegen */
                 static char _ptr_tn[TYPE_NAME_MAX];
@@ -5067,6 +5070,7 @@ static bool emit_arrays_call(CodeGen *codegen, AstNode *node, const char *func) 
             if (et->kind == TK_ARRAY) c_elem = "GrayArray";
             else if (et->kind == TK_MAP) c_elem = "GrayMap";
             else if (et->kind == TK_STRUCT) c_elem = gray_type_to_c_codegen(codegen, elem_tn);
+            else if (et->kind == TK_ENUM) c_elem = gray_type_to_c_codegen(codegen, elem_tn);
             else if (et->kind == TK_FUNCTION) c_elem = "void *";
             else if (et->kind == TK_POINTER) c_elem = gray_type_to_c_codegen(codegen, elem_tn);
         }
@@ -5108,6 +5112,9 @@ static bool emit_arrays_call(CodeGen *codegen, AstNode *node, const char *func) 
             default: break;
             }
             if (val_t->kind == TK_STRUCT) {
+                c_elem = gray_type_to_c_codegen(codegen, val_t->name);
+            }
+            if (val_t->kind == TK_ENUM) {
                 c_elem = gray_type_to_c_codegen(codegen, val_t->name);
             }
             if (val_t->kind == TK_POINTER && val_t->name) {
@@ -5260,6 +5267,7 @@ static bool emit_arrays_call(CodeGen *codegen, AstNode *node, const char *func) 
             else if (pet->kind == TK_ARRAY) pp_c_elem = "GrayArray";
             else if (pet->kind == TK_MAP) pp_c_elem = "GrayMap";
             else if (pet->kind == TK_STRUCT) pp_c_elem = gray_type_to_c_codegen(codegen, pp_elem_tn);
+            else if (pet->kind == TK_ENUM) pp_c_elem = gray_type_to_c_codegen(codegen, pp_elem_tn);
         }
         emit_formatted(codegen, "{ %s _pv = ", pp_c_elem);
         emit_expression(codegen, node->data.call.args[1]);

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -636,9 +636,9 @@ static bool type_needs_deep_copy(CodeGen *codegen, const char *gray_tn) {
     return false;
 }
 
-/* Shared counter for unique temp names across all deep-copy emitters. */
-static int deep_copy_tag_counter = 0;
-static int next_deep_copy_tag(void) { return deep_copy_tag_counter++; }
+/* Return a unique integer for temporary variable names, drawn from the
+ * codegen-wide counter so every emitter gets a distinct id. */
+static int codegen_next_id(CodeGen *codegen) { return codegen->temp_counter++; }
 
 static void emit_value_deep_copy(CodeGen *codegen, const char *gray_tn, const char *src_var);
 
@@ -679,7 +679,7 @@ static void emit_array_deep_copy(CodeGen *codegen, const char *gray_tn, const ch
         snprintf(c_elem_buf, sizeof(c_elem_buf), "%s", c_elem_ptr ? c_elem_ptr : "");
     }
     const char *c_elem = c_elem_buf;
-    int tag = next_deep_copy_tag();
+    int tag = codegen_next_id(codegen);
     emit_formatted(codegen,
         "({ GrayArray _ds%d = %s; "
         "GrayArray _dd%d = gray_array_new(gray_default_arena, sizeof(%s), _ds%d.len); "
@@ -742,7 +742,7 @@ static void emit_map_deep_copy(CodeGen *codegen, const char *gray_tn, const char
      * deep-copy each value, and insert into a fresh map. */
     const char *c_key = gray_map_element_c_type(codegen, key_tn);
     const char *c_val = gray_map_element_c_type(codegen, val_tn);
-    int tag = next_deep_copy_tag();
+    int tag = codegen_next_id(codegen);
     emit_formatted(codegen,
         "({ GrayMap _ms%d = %s; "
         "GrayMap _md%d = gray_map_new_kind(gray_default_arena, _ms%d.key_size, _ms%d.value_size, "
@@ -802,7 +802,7 @@ static void emit_struct_deep_copy(CodeGen *codegen, const char *struct_tn, const
     }
     if (emit_struct_deep_copy_depth < CYCLE_GUARD_DEPTH) emit_struct_deep_copy_visiting[emit_struct_deep_copy_depth++] = struct_tn;
     const char *c_struct = gray_type_to_c_codegen(codegen, struct_tn);
-    int tag = next_deep_copy_tag();
+    int tag = codegen_next_id(codegen);
     emit_formatted(codegen,
         "({ %s _ss%d = %s; %s _sd%d = _ss%d; ",
         c_struct, tag, src_var, c_struct, tag, tag);
@@ -848,7 +848,7 @@ static void emit_value_deep_copy(CodeGen *codegen, const char *gray_tn, const ch
  * the temp name to emit_value_deep_copy with a reconstructed "[elem]"
  * type string. */
 static void emit_deep_array_copy(CodeGen *codegen, AstNode *src_node, const char *elem_type_name) {
-    int tag = next_deep_copy_tag();
+    int tag = codegen_next_id(codegen);
     emit_formatted(codegen, "({ GrayArray _dtop%d = ", tag);
     emit_expression(codegen, src_node);
     emit(codegen, "; ");
@@ -1639,8 +1639,7 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
          * Capture counter before emitting values; nested map literals will
          * re-enter this case and increment the counter, so each level gets
          * a unique temp name. */
-        static int map_lit_counter = 0;
-        int my_counter = map_lit_counter++;
+        int my_counter = codegen_next_id(codegen);
         emit_formatted(codegen, "({ GrayMap _ml%d = gray_map_new_kind(gray_default_arena, sizeof(%s), sizeof(%s), %d, %s); ",
             my_counter, c_key_type, c_val_type, count > 4 ? count * 2 : 8,
             gray_map_key_kind_macro(c_key_type));
@@ -2560,8 +2559,7 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
                 }
             }
             if (arr_ptr_obj) {
-                static int arr_dp_ctr = 0;
-                int my_dp = arr_dp_ctr++;
+                int my_dp = codegen_next_id(codegen);
                 emit_formatted(codegen, "({ __auto_type _adp%d = ", my_dp);
                 emit_expression(codegen, arr_ptr_obj);
                 emit_formatted(codegen, "; if (!_adp%d) { gray_panic_code_at(\"%s\", %d, \"P0080\", \"nil pointer dereference\"); } "
@@ -3085,7 +3083,7 @@ static void emit_to_string(CodeGen *codegen, AstNode *arg) {
     }
     GrayType *arg_type = codegen->type_table ? typetable_get(codegen->type_table, arg) : NULL;
     if (arg_type && arg_type->kind == TK_ERROR) {
-        int tag = next_deep_copy_tag();
+        int tag = codegen_next_id(codegen);
         emit_formatted(codegen, "({ GrayError *_gray_str_err%d = (", tag);
         emit_expression(codegen, arg);
         emit_formatted(codegen, "); _gray_str_err%d ? _gray_str_err%d->message : gray_c_string_dup(gray_default_arena, \"nil\"); })", tag, tag);
@@ -3655,8 +3653,7 @@ static bool emit_builtin_call(CodeGen *codegen, AstNode *node, const char *func)
             }
         }
         if (addr_ptr_expr && addr_field) {
-            static int addr_dp_ctr = 0;
-            int my_dp = addr_dp_ctr++;
+            int my_dp = codegen_next_id(codegen);
             emit_formatted(codegen, "({ __auto_type _aadp%d = ", my_dp);
             emit_expression(codegen, addr_ptr_expr);
             emit_formatted(codegen, "; if (!_aadp%d) { gray_panic_code_at(\"%s\", %d, \"P0080\", \"nil pointer dereference\"); } "
@@ -3914,7 +3911,7 @@ static bool emit_builtin_call(CodeGen *codegen, AstNode *node, const char *func)
              * collections, collections containing such structs, and any
              * transitive mix of those all come out fully independent
              * of the source , ). */
-            int tag = next_deep_copy_tag();
+            int tag = codegen_next_id(codegen);
             const char *c_type = (arg_type->kind == TK_ARRAY) ? "GrayArray"
                                : (arg_type->kind == TK_MAP) ? "GrayMap"
                                : gray_type_to_c_codegen(codegen, arg_type->name);
@@ -7220,7 +7217,7 @@ static void emit_variable_declaration(CodeGen *codegen, AstNode *node) {
             emit_formatted(codegen, "    %s = ", sanitize_name(node->data.var_decl.name));
             if (node->data.var_decl.value &&
                 node->data.var_decl.value->kind == NODE_LABEL) {
-                int tag = next_deep_copy_tag();
+                int tag = codegen_next_id(codegen);
                 char src_var[VAR_NAME_BUF];
                 snprintf(src_var, sizeof(src_var), "_ms%d", tag);
                 emit_formatted(codegen, "({ GrayMap %s = ", src_var);
@@ -7247,7 +7244,7 @@ static void emit_variable_declaration(CodeGen *codegen, AstNode *node) {
             node->data.var_decl.value->kind == NODE_LABEL) {
             /* Copy-by-default: deep copy when assigning a map from another
              * variable so mutations to the copy don't alias the original. */
-            int tag = next_deep_copy_tag();
+            int tag = codegen_next_id(codegen);
             char src_var[VAR_NAME_BUF];
             snprintf(src_var, sizeof(src_var), "_ms%d", tag);
             emit_formatted(codegen, "({ GrayMap %s = ", src_var);
@@ -7509,7 +7506,7 @@ static void emit_variable_declaration(CodeGen *codegen, AstNode *node) {
                    type_name && type_needs_deep_copy(codegen, type_name)) {
             /* Copy-by-default: deep copy structs (and maps) that contain
              * arrays/maps/strings so the copy is fully independent. */
-            int tag = next_deep_copy_tag();
+            int tag = codegen_next_id(codegen);
             char src_var[VAR_NAME_BUF];
             snprintf(src_var, sizeof(src_var), "_vdc%d", tag);
             emit_formatted(codegen, "({ %s %s = ", c_type, src_var);
@@ -7595,8 +7592,7 @@ static void emit_assign_statement(CodeGen *codegen, AstNode *node) {
                     }
                 }
                 if (_set_ptr_obj) {
-                    static int arr_set_dp_ctr = 0;
-                    int my_dp = arr_set_dp_ctr++;
+                    int my_dp = codegen_next_id(codegen);
                     TokenType aop2 = node->data.assign.op;
                     bool is_compound2 = (aop2 == TOK_PLUS_ASSIGN || aop2 == TOK_MINUS_ASSIGN || aop2 == TOK_ASTERISK_ASSIGN);
                     emit_formatted(codegen, "{ __auto_type _asdp%d = ", my_dp);
@@ -8052,7 +8048,7 @@ static void emit_assign_statement(CodeGen *codegen, AstNode *node) {
         }
         /* Map copy-by-default: map2 = map1 deep-copies the map. */
         if (tgt_t && tgt_t->kind == TK_MAP) {
-            int tag = next_deep_copy_tag();
+            int tag = codegen_next_id(codegen);
             char src_var[VAR_NAME_BUF];
             snprintf(src_var, sizeof(src_var), "_ma%d", tag);
             emit(codegen, "{ GrayMap ");
@@ -8070,7 +8066,7 @@ static void emit_assign_statement(CodeGen *codegen, AstNode *node) {
          * the outer arena so the copy survives scope destruction. */
         if (tgt_t && tgt_t->kind == TK_STRUCT && tgt_t->name &&
             type_needs_deep_copy(codegen, tgt_t->name)) {
-            int tag = next_deep_copy_tag();
+            int tag = codegen_next_id(codegen);
             const char *ct = gray_type_to_c_codegen(codegen, tgt_t->name);
             char src_var[VAR_NAME_BUF];
             snprintf(src_var, sizeof(src_var), "_sa%d", tag);
@@ -8443,8 +8439,7 @@ static void emit_block(CodeGen *codegen, AstNode *node) {
 
 static void emit_if_statement(CodeGen *codegen, AstNode *node) {
     /* : per-block arena for if/otherwise so temporaries are freed */
-    static int if_scope_counter = 0;
-    int isc = if_scope_counter++;
+    int isc = codegen_next_id(codegen);
     emit_indent(codegen);
     emit_formatted(codegen, "{ ");
     if (codegen->loop_scope_depth == 0) {
@@ -8558,11 +8553,10 @@ static void emit_for_statement(CodeGen *codegen, AstNode *node) {
     AstNode *iter = node->data.for_stmt.iterable;
     if (iter && iter->kind == NODE_RANGE_EXPR) {
         /* for i in range(start, end) or range(start, end, step) */
-        static int blank_for_counter = 0;
-        static char blank_for_buf[64];
+        char blank_for_buf[64];
         const char *var;
         if (strcmp(node->data.for_stmt.var_name, "_") == 0) {
-            snprintf(blank_for_buf, sizeof(blank_for_buf), "_gray_for_blank_%d", blank_for_counter++);
+            snprintf(blank_for_buf, sizeof(blank_for_buf), "_gray_for_blank_%d", codegen_next_id(codegen));
             var = blank_for_buf;
         } else {
             var = sanitize_name(node->data.for_stmt.var_name);
@@ -8588,8 +8582,7 @@ static void emit_for_statement(CodeGen *codegen, AstNode *node) {
 
             if (iter->data.range_expr.step && !known_direction) {
                 /* Variable step: store step and end once, emit runtime direction ternary. */
-                static int step_var_counter = 0;
-                int svc = step_var_counter++;
+                int svc = codegen_next_id(codegen);
                 /* emit_indent already called above — use it for the var declaration line */
                 emit_formatted(codegen, "int64_t _gray_step_%d = ", svc);
                 emit_expression(codegen, iter->data.range_expr.step);
@@ -8900,9 +8893,9 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
 
         if (is_map_iter) {
             /* for_each on map; iterate occupied slots with internal counter */
-            static int map_iter_counter = 0;
+            int mi_id = codegen_next_id(codegen);
             char mi_name[SHORT_VAR_BUF];
-            snprintf(mi_name, sizeof(mi_name), "_gray_mi%d", map_iter_counter++);
+            snprintf(mi_name, sizeof(mi_name), "_gray_mi%d", mi_id);
 
             const char *c_key = "GrayString";
             const char *c_val = "int64_t";
@@ -8914,7 +8907,7 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
 
             map_needs_tmp = (coll->kind != NODE_LABEL);
             if (map_needs_tmp) {
-                snprintf(map_tmp_name, sizeof(map_tmp_name), "_gray_map%d", map_iter_counter - 1);
+                snprintf(map_tmp_name, sizeof(map_tmp_name), "_gray_map%d", mi_id);
                 emit_formatted(codegen, "{ GrayMap %s = ", map_tmp_name);
                 emit_expression(codegen, coll);
                 emit(codegen, ";\n");
@@ -8923,7 +8916,7 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
 
             /* Iterate in insertion order using the order array */
             char slot_name[SHORT_VAR_BUF];
-            snprintf(slot_name, sizeof(slot_name), "_gray_sl%d", map_iter_counter - 1);
+            snprintf(slot_name, sizeof(slot_name), "_gray_sl%d", mi_id);
             /* Guard against mutation during iteration */
             {
                 char *ge = iter_guard_expr(codegen, map_needs_tmp, map_tmp_name, coll);
@@ -9010,16 +9003,16 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
             /* Snapshot the array length at loop start so appending during
              * iteration doesn't cause an infinite loop. The loop visits
              * only the elements that existed when for_each began. */
-            static int arr_iter_counter = 0;
+            int alen_id = codegen_next_id(codegen);
             char len_name[SHORT_VAR_BUF];
-            snprintf(len_name, sizeof(len_name), "_gray_alen%d", arr_iter_counter++);
+            snprintf(len_name, sizeof(len_name), "_gray_alen%d", alen_id);
             /* When the collection is a non-assignable expression (inline array
              * literal, function return, etc.) it is an rvalue in C and
              * cannot be mutated (.iterating++) or addressed (GRAY_ARRAY_GET).
              * Assign it to a named temporary first. */
             coll_needs_tmp = (coll->kind != NODE_LABEL);
             if (coll_needs_tmp) {
-                snprintf(arr_tmp_name, sizeof(arr_tmp_name), "_gray_arr%d", arr_iter_counter - 1);
+                snprintf(arr_tmp_name, sizeof(arr_tmp_name), "_gray_arr%d", alen_id);
                 emit_formatted(codegen, "{ GrayArray %s = ", arr_tmp_name);
                 emit_expression(codegen, coll);
                 emit(codegen, ";\n");
@@ -9124,9 +9117,8 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
         /* Evaluate the match expression once into a temporary so that
          * side-effecting expressions (function calls, increments, etc.)
          * are not re-executed for each is-arm. */
-        static int when_tmp_ctr = 0;
         char when_tmp[64];
-        snprintf(when_tmp, sizeof(when_tmp), "_gray_when%d", when_tmp_ctr++);
+        snprintf(when_tmp, sizeof(when_tmp), "_gray_when%d", codegen_next_id(codegen));
         emit_indent(codegen);
         emit_formatted(codegen, "__auto_type %s = ", when_tmp);
         emit_expression(codegen, val);
@@ -9413,6 +9405,7 @@ CodeGen codegen_create(const char *file) {
     codegen.ns_func_names = NULL;
     codegen.ns_func_name_count = 0;
     codegen.ns_func_name_cap = 0;
+    codegen.temp_counter = 0;
     return codegen;
 }
 

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -5063,6 +5063,8 @@ static bool emit_arrays_call(CodeGen *codegen, AstNode *node, const char *func) 
             case TK_UINT: c_elem = "uint64_t"; break;
             case TK_FLOAT: c_elem = "double"; break;
             case TK_BOOL: c_elem = "bool"; break;
+            case TK_CHAR: c_elem = "int32_t"; break;
+            case TK_BYTE: c_elem = "uint8_t"; break;
             case TK_STRING: c_elem = "GrayString"; break;
             case TK_ARRAY: c_elem = "GrayArray"; break;
             case TK_MAP: c_elem = "GrayMap"; break;
@@ -5125,6 +5127,8 @@ static bool emit_arrays_call(CodeGen *codegen, AstNode *node, const char *func) 
             case TK_UINT: c_elem = "uint64_t"; break;
             case TK_FLOAT: c_elem = "double"; break;
             case TK_BOOL: c_elem = "bool"; break;
+            case TK_CHAR: c_elem = "int32_t"; break;
+            case TK_BYTE: c_elem = "uint8_t"; break;
             case TK_STRING: c_elem = "GrayString"; break;
             case TK_FUNCTION: c_elem = "void *"; break;
             default: break;
@@ -5281,6 +5285,8 @@ static bool emit_arrays_call(CodeGen *codegen, AstNode *node, const char *func) 
             GrayType *pet = type_from_name(pp_elem_tn);
             if (pet->kind == TK_FLOAT) pp_c_elem = "double";
             else if (pet->kind == TK_BOOL) pp_c_elem = "bool";
+            else if (pet->kind == TK_CHAR) pp_c_elem = "int32_t";
+            else if (pet->kind == TK_BYTE) pp_c_elem = "uint8_t";
             else if (pet->kind == TK_STRING) pp_c_elem = "GrayString";
             else if (pet->kind == TK_ARRAY) pp_c_elem = "GrayArray";
             else if (pet->kind == TK_MAP) pp_c_elem = "GrayMap";

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -5329,7 +5329,15 @@ static bool emit_arrays_call(CodeGen *codegen, AstNode *node, const char *func) 
             GrayType *fet = type_from_name(fl_arr_t->element_type);
             if (fet->kind == TK_FLOAT) fl_c_elem = "double";
             else if (fet->kind == TK_BOOL) fl_c_elem = "bool";
+            else if (fet->kind == TK_CHAR) fl_c_elem = "int32_t";
+            else if (fet->kind == TK_BYTE) fl_c_elem = "uint8_t";
             else if (fet->kind == TK_STRING) fl_c_elem = "GrayString";
+            else if (fet->kind == TK_ARRAY) fl_c_elem = "GrayArray";
+            else if (fet->kind == TK_MAP) fl_c_elem = "GrayMap";
+            else if (fet->kind == TK_STRUCT) fl_c_elem = gray_type_to_c_codegen(codegen, fl_arr_t->element_type);
+            else if (fet->kind == TK_ENUM) fl_c_elem = gray_type_to_c_codegen(codegen, fl_arr_t->element_type);
+            else if (fet->kind == TK_INT || fet->kind == TK_UINT)
+                fl_c_elem = gray_type_to_c_codegen(codegen, fl_arr_t->element_type);
         }
         emit_formatted(codegen, "{ %s _fv = ", fl_c_elem);
         emit_expression(codegen, node->data.call.args[1]);

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -1380,6 +1380,9 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
                         else if (et->kind == TK_UINT) ek = 4;
                         else if (et->kind == TK_BYTE) ek = 5;
                         else if (et->kind == TK_CHAR) ek = 6;
+                        else if (et->kind == TK_ENUM) {
+                            ek = (part_type->element_type && codegen_enum_is_string(codegen, part_type->element_type)) ? 2 : 7;
+                        }
                     }
                     emit_formatted(codegen, "({ GrayArray _interp_arr = ");
                     emit_expression(codegen, part);
@@ -1396,6 +1399,9 @@ static void emit_expression(CodeGen *codegen, AstNode *node) {
                         else if (vt->kind == TK_UINT) vk = 4;
                         else if (vt->kind == TK_BYTE) vk = 5;
                         else if (vt->kind == TK_CHAR) vk = 6;
+                        else if (vt->kind == TK_ENUM) {
+                            vk = (part_type->value_type && codegen_enum_is_string(codegen, part_type->value_type)) ? 2 : 7;
+                        }
                     }
                     emit_formatted(codegen, "({ GrayMap _interp_map = ");
                     emit_expression(codegen, part);

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -881,13 +881,6 @@ static void register_reference_variable(CodeGen *codegen, const char *name) {
     codegen->ref_vars[codegen->ref_var_count++] = name;
 }
 
-/* Check if a type name is a wide integer type (i128/u128/i256/u256) */
-static bool is_bigint_type(const char *type_str) {
-    if (!type_str) return false;
-    return strcmp(type_str, "i128") == 0 || strcmp(type_str, "u128") == 0 ||
-           strcmp(type_str, "i256") == 0 || strcmp(type_str, "u256") == 0;
-}
-
 /* Returns true if the named enum is string-backed. */
 static bool codegen_enum_is_string(CodeGen *codegen, const char *name) {
     if (!name) return false;

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -5071,6 +5071,11 @@ static bool emit_arrays_call(CodeGen *codegen, AstNode *node, const char *func) 
             case TK_FUNCTION: c_elem = "void *"; break;
             default: break;
             }
+            /* Wide ints share TK_INT/TK_UINT but need their own C types */
+            if (val_t->name && (val_t->kind == TK_INT || val_t->kind == TK_UINT)) {
+                const char *mapped = gray_type_to_c_codegen(codegen, val_t->name);
+                if (mapped) c_elem = mapped;
+            }
             if (val_t->kind == TK_STRUCT) {
                 c_elem = gray_type_to_c_codegen(codegen, val_t->name);
             }
@@ -5132,6 +5137,11 @@ static bool emit_arrays_call(CodeGen *codegen, AstNode *node, const char *func) 
             case TK_STRING: c_elem = "GrayString"; break;
             case TK_FUNCTION: c_elem = "void *"; break;
             default: break;
+            }
+            /* Wide ints share TK_INT/TK_UINT but need their own C types */
+            if (val_t->name && (val_t->kind == TK_INT || val_t->kind == TK_UINT)) {
+                const char *mapped = gray_type_to_c_codegen(codegen, val_t->name);
+                if (mapped) c_elem = mapped;
             }
             if (val_t->kind == TK_STRUCT) {
                 c_elem = gray_type_to_c_codegen(codegen, val_t->name);
@@ -5292,6 +5302,8 @@ static bool emit_arrays_call(CodeGen *codegen, AstNode *node, const char *func) 
             else if (pet->kind == TK_MAP) pp_c_elem = "GrayMap";
             else if (pet->kind == TK_STRUCT) pp_c_elem = gray_type_to_c_codegen(codegen, pp_elem_tn);
             else if (pet->kind == TK_ENUM) pp_c_elem = gray_type_to_c_codegen(codegen, pp_elem_tn);
+            else if (pet->kind == TK_INT || pet->kind == TK_UINT)
+                pp_c_elem = gray_type_to_c_codegen(codegen, pp_elem_tn);
         }
         emit_formatted(codegen, "{ %s _pv = ", pp_c_elem);
         emit_expression(codegen, node->data.call.args[1]);

--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -877,10 +877,7 @@ static bool is_reference_variable(CodeGen *codegen, const char *name) {
 }
 
 static void register_reference_variable(CodeGen *codegen, const char *name) {
-    if (codegen->ref_var_count >= codegen->ref_var_cap) {
-        codegen->ref_var_cap = codegen->ref_var_cap ? codegen->ref_var_cap * 2 : 8;
-        codegen->ref_vars = xrealloc(codegen->ref_vars, sizeof(const char *) * codegen->ref_var_cap);
-    }
+    GROW_ARRAY(codegen->ref_vars, codegen->ref_var_count, codegen->ref_var_cap);
     codegen->ref_vars[codegen->ref_var_count++] = name;
 }
 
@@ -8186,11 +8183,7 @@ static void emit_ensure_cleanup(CodeGen *codegen) {
  * `or_return`) from inside a nested for_each/if/while/loop scope leaks
  * the per-scope arenas the codegen had emitted. */
 static void scope_arena_push(CodeGen *codegen, const char *arena_var, const char *saved_var) {
-    if (codegen->scope_arena_count >= codegen->scope_arena_cap) {
-        codegen->scope_arena_cap = codegen->scope_arena_cap ? codegen->scope_arena_cap * 2 : 8;
-        codegen->scope_arenas = xrealloc(codegen->scope_arenas,
-            sizeof(ScopeArena) * (size_t)codegen->scope_arena_cap);
-    }
+    GROW_ARRAY(codegen->scope_arenas, codegen->scope_arena_count, codegen->scope_arena_cap);
     ScopeArena *entry = &codegen->scope_arenas[codegen->scope_arena_count++];
     snprintf(entry->arena_var, sizeof(entry->arena_var), "%s", arena_var);
     snprintf(entry->saved_var, sizeof(entry->saved_var), "%s", saved_var);
@@ -8203,11 +8196,7 @@ static void scope_arena_pop(CodeGen *codegen) {
 /* Track active for_each iteration guards so early-return paths can
  * decrement .iterating for every live for_each loop. */
 static void iter_guard_push(CodeGen *codegen, const char *expr) {
-    if (codegen->iter_guard_count >= codegen->iter_guard_cap) {
-        codegen->iter_guard_cap = codegen->iter_guard_cap ? codegen->iter_guard_cap * 2 : 4;
-        codegen->iter_guards = xrealloc(codegen->iter_guards,
-            sizeof(char *) * (size_t)codegen->iter_guard_cap);
-    }
+    GROW_ARRAY(codegen->iter_guards, codegen->iter_guard_count, codegen->iter_guard_cap);
     codegen->iter_guards[codegen->iter_guard_count++] = strdup(expr);
 }
 
@@ -9331,11 +9320,8 @@ static void emit_statement(CodeGen *codegen, AstNode *node) {
         /* Function-scoped using: add to using_modules so bare-name
          * dispatch works for the rest of this function body. */
         for (int j = 0; j < node->data.using_stmt.count; j++) {
-            if (codegen->using_module_count >= codegen->using_module_cap) {
-                codegen->using_module_cap = codegen->using_module_cap ? codegen->using_module_cap * 2 : 8;
-                codegen->using_modules = xrealloc(codegen->using_modules,
-                    sizeof(const char *) * (size_t)codegen->using_module_cap);
-            }
+            GROW_ARRAY(codegen->using_modules, codegen->using_module_count,
+                codegen->using_module_cap);
             codegen->using_modules[codegen->using_module_count++] = node->data.using_stmt.modules[j];
         }
         break;
@@ -9485,21 +9471,15 @@ void codegen_generate(CodeGen *codegen, AstNode *program) {
                 /* Collect C interop headers */
                 if (item->is_c_import && item->path) {
                     codegen->has_c_imports = true;
-                    if (codegen->c_header_count >= codegen->c_header_cap) {
-                        codegen->c_header_cap = codegen->c_header_cap ? codegen->c_header_cap * 2 : 4;
-                        codegen->c_headers = xrealloc(codegen->c_headers,
-                            sizeof(const char *) * (size_t)codegen->c_header_cap);
-                    }
+                    GROW_ARRAY(codegen->c_headers, codegen->c_header_count,
+                        codegen->c_header_cap);
                     codegen->c_headers[codegen->c_header_count++] = item->path;
                 }
                 /* Track all imported module names */
                 if (item->module) {
                     const char *mname = item->alias ? item->alias : item->module;
-                    if (codegen->imported_module_count >= codegen->imported_module_cap) {
-                        codegen->imported_module_cap = codegen->imported_module_cap ? codegen->imported_module_cap * 2 : 8;
-                        codegen->imported_modules = xrealloc(codegen->imported_modules,
-                            sizeof(const char *) * (size_t)codegen->imported_module_cap);
-                    }
+                    GROW_ARRAY(codegen->imported_modules, codegen->imported_module_count,
+                        codegen->imported_module_cap);
                     codegen->imported_modules[codegen->imported_module_count++] = mname;
                 }
                 /* Track alias → module mapping */
@@ -9521,11 +9501,8 @@ void codegen_generate(CodeGen *codegen, AstNode *program) {
                 for (int j = 0; j < stmt->data.import_stmt.count; j++) {
                     ImportItem *item = &stmt->data.import_stmt.items[j];
                     if (item->module) {
-                        if (codegen->using_module_count >= codegen->using_module_cap) {
-                            codegen->using_module_cap = codegen->using_module_cap ? codegen->using_module_cap * 2 : 8;
-                            codegen->using_modules = xrealloc(codegen->using_modules,
-                                sizeof(const char *) * (size_t)codegen->using_module_cap);
-                        }
+                        GROW_ARRAY(codegen->using_modules, codegen->using_module_count,
+                            codegen->using_module_cap);
                         codegen->using_modules[codegen->using_module_count++] = item->module;
                     }
                 }
@@ -9533,11 +9510,8 @@ void codegen_generate(CodeGen *codegen, AstNode *program) {
         }
         if (stmt->kind == NODE_USING_STMT) {
             for (int j = 0; j < stmt->data.using_stmt.count; j++) {
-                if (codegen->using_module_count >= codegen->using_module_cap) {
-                    codegen->using_module_cap = codegen->using_module_cap ? codegen->using_module_cap * 2 : 8;
-                    codegen->using_modules = xrealloc(codegen->using_modules,
-                        sizeof(const char *) * (size_t)codegen->using_module_cap);
-                }
+                GROW_ARRAY(codegen->using_modules, codegen->using_module_count,
+                    codegen->using_module_cap);
                 codegen->using_modules[codegen->using_module_count++] = stmt->data.using_stmt.modules[j];
             }
         }
@@ -9556,11 +9530,8 @@ void codegen_generate(CodeGen *codegen, AstNode *program) {
             continue; /* aliases are erased — not emitted */
         }
         if (stmt->kind == NODE_STRUCT_DECL) {
-            if (codegen->struct_decl_count >= codegen->struct_decl_cap) {
-                codegen->struct_decl_cap = codegen->struct_decl_cap ? codegen->struct_decl_cap * 2 : 16;
-                codegen->struct_decls = xrealloc(codegen->struct_decls,
-                    sizeof(AstNode *) * (size_t)codegen->struct_decl_cap);
-            }
+            GROW_ARRAY(codegen->struct_decls, codegen->struct_decl_count,
+                codegen->struct_decl_cap);
             codegen->struct_decls[codegen->struct_decl_count++] = stmt;
         } else if (stmt->kind == NODE_ENUM_DECL) {
             BUCKET_PUSH(enum_bucket, enum_bucket_count, enum_bucket_cap, stmt);
@@ -9957,10 +9928,7 @@ void codegen_generate(CodeGen *codegen, AstNode *program) {
     /* Collect all function declarations (including struct-namespaced) */
     for (int i = 0; i < func_bucket_count; i++) {
         AstNode *stmt = func_bucket[i];
-        if (codegen->func_count >= codegen->func_cap) {
-            codegen->func_cap = codegen->func_cap ? codegen->func_cap * 2 : 16;
-            codegen->all_funcs = xrealloc(codegen->all_funcs, sizeof(AstNode *) * codegen->func_cap);
-        }
+        GROW_ARRAY(codegen->all_funcs, codegen->func_count, codegen->func_cap);
         codegen->all_funcs[codegen->func_count++] = stmt;
     }
     /* Collect struct-namespaced functions with prefixed names */
@@ -9977,16 +9945,11 @@ void codegen_generate(CodeGen *codegen, AstNode *program) {
                 char *ns_name = malloc(ns_len);
                 snprintf(ns_name, ns_len, "%s_%s", struct_name, fn_name);
                 function_node->data.func_decl.name = ns_name;
-                if (codegen->ns_func_name_count >= codegen->ns_func_name_cap) {
-                    codegen->ns_func_name_cap = codegen->ns_func_name_cap ? codegen->ns_func_name_cap * 2 : 8;
-                    codegen->ns_func_names = xrealloc(codegen->ns_func_names, sizeof(char *) * codegen->ns_func_name_cap);
-                }
+                GROW_ARRAY(codegen->ns_func_names, codegen->ns_func_name_count,
+                    codegen->ns_func_name_cap);
                 codegen->ns_func_names[codegen->ns_func_name_count++] = ns_name;
 
-                if (codegen->func_count >= codegen->func_cap) {
-                    codegen->func_cap = codegen->func_cap ? codegen->func_cap * 2 : 16;
-                    codegen->all_funcs = xrealloc(codegen->all_funcs, sizeof(AstNode *) * codegen->func_cap);
-                }
+                GROW_ARRAY(codegen->all_funcs, codegen->func_count, codegen->func_cap);
                 codegen->all_funcs[codegen->func_count++] = function_node;
             }
         }

--- a/grayc/src/codegen/codegen.h
+++ b/grayc/src/codegen/codegen.h
@@ -135,6 +135,11 @@ typedef struct {
      * emitted as C file-scope initializers, which C does not allow. */
     bool in_const_decl;
 
+    /* Monotonic counter for generating unique temporary variable names.
+     * Every emitter that needs a unique C identifier draws from this
+     * single counter via codegen_next_id(). */
+    int temp_counter;
+
     /* Stack of open per-scope scratch arenas (if / for_each / while /
      * loop). Each entry holds the exact C identifiers emitted at scope
      * entry so any early-exit path (return, or_return-desugared return)

--- a/grayc/src/parser/parser.c
+++ b/grayc/src/parser/parser.c
@@ -2405,7 +2405,7 @@ static AstNode *parse_enum_declaration(Parser *parser) {
         /* Check for payload types: VARIANT(type1, type2, ...) */
         if (peek_token_is(parser, TOK_LPAREN)) {
             next_token(parser); /* consume ( */
-            next_token(parser); /* first type */
+            next_token(parser); /* first token of first type */
             int pt_cap = 4;
             ev->payload_types = arena_alloc(parser->arena, sizeof(const char *) * pt_cap);
             while (!current_token_is(parser, TOK_RPAREN) && !current_token_is(parser, TOK_EOF)) {
@@ -2415,8 +2415,10 @@ static AstNode *parse_enum_declaration(Parser *parser) {
                     memcpy(new_pt, ev->payload_types, sizeof(const char *) * ev->payload_count);
                     ev->payload_types = new_pt;
                 }
-                ev->payload_types[ev->payload_count++] = parser->cur_token.literal;
-                next_token(parser);
+                const char *type_str = parse_complex_type(parser);
+                if (!type_str) return NULL;
+                ev->payload_types[ev->payload_count++] = type_str;
+                next_token(parser); /* advance past last token of type */
                 if (current_token_is(parser, TOK_COMMA)) next_token(parser);
             }
             /* cur_token is now TOK_RPAREN */

--- a/grayc/src/parser/parser.c
+++ b/grayc/src/parser/parser.c
@@ -1293,12 +1293,17 @@ static AstNode *maybe_apply_or_return(Parser *parser, AstNode *var_decl) {
     err_access2->data.member.object = tmp_label2;
     err_access2->data.member.member = "v1";
     if (fallback_count > 0) {
-        /* Custom fallback: return fallback_vals..., _tmp.v1 */
-        int total = fallback_count + 1;
+        /* Custom fallback values. If the user provided enough values to
+         * cover all return slots (including the error), use them as-is.
+         * Otherwise append the propagated error (_tmp.v1). */
+        int func_ret = parser->current_func ? parser->current_func->data.func_decl.return_type_count : 0;
+        bool user_covers_error = (func_ret > 0 && fallback_count >= func_ret);
+        int total = user_covers_error ? fallback_count : fallback_count + 1;
         ret_stmt->data.return_stmt.values = arena_alloc(parser->arena, sizeof(AstNode *) * total);
         for (int i = 0; i < fallback_count; i++)
             ret_stmt->data.return_stmt.values[i] = fallback_buf[i];
-        ret_stmt->data.return_stmt.values[fallback_count] = err_access2;
+        if (!user_covers_error)
+            ret_stmt->data.return_stmt.values[fallback_count] = err_access2;
         ret_stmt->data.return_stmt.count = total;
     } else {
         /* Bare or_return: propagate just the error; codegen fills {0} for other slots */
@@ -1919,7 +1924,10 @@ static AstNode *parse_func_declaration(Parser *parser) {
 
     /* Body */
     if (!expect_peek_token(parser, TOK_LBRACE)) return NULL;
+    AstNode *saved_func = parser->current_func;
+    parser->current_func = node;
     node->data.func_decl.body = parse_block_statement(parser);
+    parser->current_func = saved_func;
 
     return node;
 }
@@ -3127,6 +3135,7 @@ Parser *parser_create(Arena *arena, Lexer *lexer, const char *file, DiagnosticLi
     parser->diag = diag;
     parser->depth = 0;
     parser->no_struct_literal = false;
+    parser->current_func = NULL;
 
     /* Read two tokens to fill cur and peek */
     next_token(parser);

--- a/grayc/src/parser/parser.c
+++ b/grayc/src/parser/parser.c
@@ -9,6 +9,7 @@
  */
 
 #include "parser.h"
+#include "../typechecker/types.h"
 #include "../util/constants.h"
 #include "../util/reserved.h"
 #include <stdio.h>
@@ -1810,17 +1811,10 @@ static AstNode *parse_func_declaration(Parser *parser) {
                 bool is_type = false;
                 if (current_token_is(parser, TOK_IDENT)) {
                     const char *lit = parser->cur_token.literal;
-                    is_type = (strcmp(lit, "int") == 0 || strcmp(lit, "uint") == 0 ||
-                        strcmp(lit, "i8") == 0 || strcmp(lit, "i16") == 0 ||
-                        strcmp(lit, "i32") == 0 || strcmp(lit, "i64") == 0 ||
-                        strcmp(lit, "i128") == 0 || strcmp(lit, "i256") == 0 ||
-                        strcmp(lit, "u8") == 0 || strcmp(lit, "u16") == 0 ||
-                        strcmp(lit, "u32") == 0 || strcmp(lit, "u64") == 0 ||
-                        strcmp(lit, "u128") == 0 || strcmp(lit, "u256") == 0 ||
+                    is_type = (is_any_int_type(lit) ||
                         strcmp(lit, "float") == 0 || strcmp(lit, "f32") == 0 ||
                         strcmp(lit, "f64") == 0 || strcmp(lit, "string") == 0 ||
                         strcmp(lit, "bool") == 0 || strcmp(lit, "char") == 0 ||
-                        strcmp(lit, "byte") == 0 ||
                         (strcmp(lit, "map") == 0 && peek_token_is(parser, TOK_LBRACKET)) ||
                         (strcmp(lit, "func") == 0 && peek_token_is(parser, TOK_LPAREN)) ||
                         (lit[0] >= 'A' && lit[0] <= 'Z')); /* struct/enum types */

--- a/grayc/src/parser/parser.c
+++ b/grayc/src/parser/parser.c
@@ -2645,6 +2645,51 @@ static AstNode *parse_loop_statement(Parser *parser) {
     return node;
 }
 
+/* --- Speculative parse helpers for when-pattern detection --- */
+
+typedef struct {
+    int position, read_position;
+    char ch;
+    int line, column;
+    Token cur_token, peek_token;
+} ParserSnapshot;
+
+static void parser_snapshot_save(Parser *parser, ParserSnapshot *snap) {
+    snap->position = parser->lexer->position;
+    snap->read_position = parser->lexer->read_position;
+    snap->ch = parser->lexer->ch;
+    snap->line = parser->lexer->line;
+    snap->column = parser->lexer->column;
+    snap->cur_token = parser->cur_token;
+    snap->peek_token = parser->peek_token;
+}
+
+static void parser_snapshot_restore(Parser *parser, const ParserSnapshot *snap) {
+    parser->lexer->position = snap->position;
+    parser->lexer->read_position = snap->read_position;
+    parser->lexer->ch = snap->ch;
+    parser->lexer->line = snap->line;
+    parser->lexer->column = snap->column;
+    parser->cur_token = snap->cur_token;
+    parser->peek_token = snap->peek_token;
+}
+
+/* Check if current position holds IDENT(IDENT, ..., IDENT).
+ * Assumes cur_token is the IDENT before LPAREN and peek is LPAREN.
+ * Consumes tokens past the closing paren (caller must restore). */
+static bool scan_paren_bindings(Parser *parser) {
+    next_token(parser); /* skip IDENT */
+    next_token(parser); /* skip ( */
+    int bind_count = 0;
+    while (!current_token_is(parser, TOK_RPAREN) && !current_token_is(parser, TOK_EOF)) {
+        if (!current_token_is(parser, TOK_IDENT)) return false;
+        bind_count++;
+        next_token(parser);
+        if (current_token_is(parser, TOK_COMMA)) next_token(parser);
+    }
+    return bind_count > 0 && current_token_is(parser, TOK_RPAREN);
+}
+
 static AstNode *parse_when_statement(Parser *parser) {
     AstNode *node = ast_alloc(parser->arena, NODE_WHEN_STMT, parser->cur_token);
 
@@ -2692,111 +2737,32 @@ static AstNode *parse_when_statement(Parser *parser) {
                 Token pat_tok = parser->cur_token;
 
                 if (current_token_is(parser, TOK_IDENT) && peek_token_is(parser, TOK_LPAREN)) {
-                    /* Save lexer state for lookahead */
-                    int sv_pos  = parser->lexer->position;
-                    int sv_rpos = parser->lexer->read_position;
-                    char sv_ch  = parser->lexer->ch;
-                    int sv_line = parser->lexer->line;
-                    int sv_col  = parser->lexer->column;
-                    Token sv_cur  = parser->cur_token;
-                    Token sv_peek = parser->peek_token;
-
-                    const char *vname = parser->cur_token.literal;
-                    next_token(parser); /* skip IDENT */
-                    next_token(parser); /* skip ( */
-                    bool all_idents = true;
-                    int bind_count = 0;
-                    while (!current_token_is(parser, TOK_RPAREN) && !current_token_is(parser, TOK_EOF)) {
-                        if (!current_token_is(parser, TOK_IDENT)) { all_idents = false; break; }
-                        bind_count++;
-                        next_token(parser);
-                        if (current_token_is(parser, TOK_COMMA)) next_token(parser);
-                    }
-                    if (all_idents && bind_count > 0 && current_token_is(parser, TOK_RPAREN)) {
-                        try_pattern = true;
-                        (void)vname;
-                    }
-                    /* Restore lexer state */
-                    parser->lexer->position = sv_pos;
-                    parser->lexer->read_position = sv_rpos;
-                    parser->lexer->ch = sv_ch;
-                    parser->lexer->line = sv_line;
-                    parser->lexer->column = sv_col;
-                    parser->cur_token  = sv_cur;
-                    parser->peek_token = sv_peek;
+                    /* IDENT(IDENT,...) pattern form */
+                    ParserSnapshot snap;
+                    parser_snapshot_save(parser, &snap);
+                    try_pattern = scan_paren_bindings(parser);
+                    parser_snapshot_restore(parser, &snap);
                 } else if (current_token_is(parser, TOK_IDENT) && peek_token_is(parser, TOK_DOT)) {
                     /* IDENT.IDENT(IDENT,...) explicit enum pattern form */
-                    int sv_pos  = parser->lexer->position;
-                    int sv_rpos = parser->lexer->read_position;
-                    char sv_ch  = parser->lexer->ch;
-                    int sv_line = parser->lexer->line;
-                    int sv_col  = parser->lexer->column;
-                    Token sv_cur  = parser->cur_token;
-                    Token sv_peek = parser->peek_token;
-
-                    next_token(parser); /* skip first IDENT (enum name) */
+                    ParserSnapshot snap;
+                    parser_snapshot_save(parser, &snap);
+                    next_token(parser); /* skip enum name */
                     next_token(parser); /* skip DOT */
                     if (current_token_is(parser, TOK_IDENT) && peek_token_is(parser, TOK_LPAREN)) {
-                        next_token(parser); /* skip second IDENT (variant) */
-                        next_token(parser); /* skip ( */
-                        bool all_idents = true;
-                        int bind_count = 0;
-                        while (!current_token_is(parser, TOK_RPAREN) && !current_token_is(parser, TOK_EOF)) {
-                            if (!current_token_is(parser, TOK_IDENT)) { all_idents = false; break; }
-                            bind_count++;
-                            next_token(parser);
-                            if (current_token_is(parser, TOK_COMMA)) next_token(parser);
-                        }
-                        if (all_idents && bind_count > 0 && current_token_is(parser, TOK_RPAREN)) {
-                            try_pattern = true;
-                            is_explicit_enum = true;
-                        }
+                        try_pattern = scan_paren_bindings(parser);
+                        if (try_pattern) is_explicit_enum = true;
                     }
-                    /* Restore lexer state */
-                    parser->lexer->position = sv_pos;
-                    parser->lexer->read_position = sv_rpos;
-                    parser->lexer->ch = sv_ch;
-                    parser->lexer->line = sv_line;
-                    parser->lexer->column = sv_col;
-                    parser->cur_token  = sv_cur;
-                    parser->peek_token = sv_peek;
+                    parser_snapshot_restore(parser, &snap);
                 } else if (current_token_is(parser, TOK_DOT) && peek_token_is(parser, TOK_IDENT)) {
-                    /* .IDENT(IDENT,...) form */
-                    int sv_pos  = parser->lexer->position;
-                    int sv_rpos = parser->lexer->read_position;
-                    char sv_ch  = parser->lexer->ch;
-                    int sv_line = parser->lexer->line;
-                    int sv_col  = parser->lexer->column;
-                    Token sv_cur  = parser->cur_token;
-                    Token sv_peek = parser->peek_token;
-
+                    /* .IDENT(IDENT,...) implicit pattern form */
+                    ParserSnapshot snap;
+                    parser_snapshot_save(parser, &snap);
                     next_token(parser); /* skip dot */
-                    const char *vname = parser->cur_token.literal;
                     if (peek_token_is(parser, TOK_LPAREN)) {
-                        next_token(parser); /* skip IDENT */
-                        next_token(parser); /* skip ( */
-                        bool all_idents = true;
-                        int bind_count = 0;
-                        while (!current_token_is(parser, TOK_RPAREN) && !current_token_is(parser, TOK_EOF)) {
-                            if (!current_token_is(parser, TOK_IDENT)) { all_idents = false; break; }
-                            bind_count++;
-                            next_token(parser);
-                            if (current_token_is(parser, TOK_COMMA)) next_token(parser);
-                        }
-                        if (all_idents && bind_count > 0 && current_token_is(parser, TOK_RPAREN)) {
-                            try_pattern = true;
-                            is_implicit_pat = true;
-                            (void)vname;
-                        }
+                        try_pattern = scan_paren_bindings(parser);
+                        if (try_pattern) is_implicit_pat = true;
                     }
-                    /* Restore lexer state */
-                    parser->lexer->position = sv_pos;
-                    parser->lexer->read_position = sv_rpos;
-                    parser->lexer->ch = sv_ch;
-                    parser->lexer->line = sv_line;
-                    parser->lexer->column = sv_col;
-                    parser->cur_token  = sv_cur;
-                    parser->peek_token = sv_peek;
+                    parser_snapshot_restore(parser, &snap);
                 }
 
                 if (try_pattern) {

--- a/grayc/src/parser/parser.h
+++ b/grayc/src/parser/parser.h
@@ -28,6 +28,7 @@ typedef struct {
     int depth;
     bool no_struct_literal; /* suppress struct literal parsing (RHS of in/not_in) */
     bool in_interp;         /* true when parsing a ${...} sub-expression */
+    AstNode *current_func;  /* enclosing function node (for or_return) */
 } Parser;
 
 Parser *parser_create(Arena *arena, Lexer *lexer, const char *file, DiagnosticList *diag);

--- a/grayc/src/runtime/runtime.c
+++ b/grayc/src/runtime/runtime.c
@@ -9,15 +9,9 @@
  */
 
 #include "runtime.h"
+#include "util/colors.h"
 #include <stdarg.h>
 #include <unistd.h>
-
-/* --- ANSI color codes for panic output --- */
-
-#define P_RESET   "\033[0m"
-#define P_BOLD    "\033[1m"
-#define P_RED     "\033[31m"
-#define P_BLUE    "\033[34m"
 
 static inline int panic_use_color(void) {
     return isatty(STDERR_FILENO) && !getenv("NO_COLOR");
@@ -234,46 +228,43 @@ void gray_runtime_shutdown(void) {
 
 /* --- Panic --- */
 
-void gray_panic(const char *file, int line, const char *fmt, ...) {
+static _Noreturn void gray_panic_impl(const char *code, const char *file,
+    int line, const char *fmt, va_list args) {
     fflush(stdout);
     int c = panic_use_color();
-    fprintf(stderr, "%s%spanic%s at %s:%d: %s",
-        c ? P_BOLD : "", c ? P_RED : "", c ? P_RESET : "",
-        file, line,
-        c ? P_BOLD : "");
+
+    /* Label: "panic" or "panic[CODE]" in bold red */
+    fprintf(stderr, "%s%spanic", c ? COL_BOLD : "", c ? COL_RED : "");
+    if (code) {
+        fprintf(stderr, "[%s]", code);
+        if (!file) fputc(':', stderr);
+    }
+    fprintf(stderr, "%s", c ? COL_RESET : "");
+
+    /* Location (uncolored) */
+    if (file) fprintf(stderr, " at %s:%d:", file, line);
+
+    /* Message in bold */
+    fprintf(stderr, " %s", c ? COL_BOLD : "");
+    vfprintf(stderr, fmt, args);
+    fprintf(stderr, "%s\n", c ? COL_RESET : "");
+    exit(1);
+}
+
+void gray_panic(const char *file, int line, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
-    vfprintf(stderr, fmt, args);
-    va_end(args);
-    fprintf(stderr, "%s\n", c ? P_RESET : "");
-    exit(1);
+    gray_panic_impl(NULL, file, line, fmt, args);
 }
 
 void gray_panic_code(const char *code, const char *fmt, ...) {
-    fflush(stdout);
-    int c = panic_use_color();
-    fprintf(stderr, "%s%spanic[%s]:%s %s",
-        c ? P_BOLD : "", c ? P_RED : "", code, c ? P_RESET : "",
-        c ? P_BOLD : "");
     va_list args;
     va_start(args, fmt);
-    vfprintf(stderr, fmt, args);
-    va_end(args);
-    fprintf(stderr, "%s\n", c ? P_RESET : "");
-    exit(1);
+    gray_panic_impl(code, NULL, 0, fmt, args);
 }
 
 void gray_panic_code_at(const char *file, int line, const char *code, const char *fmt, ...) {
-    fflush(stdout);
-    int c = panic_use_color();
-    fprintf(stderr, "%s%spanic[%s]%s at %s:%d: %s",
-        c ? P_BOLD : "", c ? P_RED : "", code, c ? P_RESET : "",
-        file, line,
-        c ? P_BOLD : "");
     va_list args;
     va_start(args, fmt);
-    vfprintf(stderr, fmt, args);
-    va_end(args);
-    fprintf(stderr, "%s\n", c ? P_RESET : "");
-    exit(1);
+    gray_panic_impl(code, file, line, fmt, args);
 }

--- a/grayc/src/runtime/runtime.h
+++ b/grayc/src/runtime/runtime.h
@@ -108,6 +108,15 @@ GrayString gray_c_string_dup(GrayArena *arena, const char *s);
 /* String formatting (for interpolation) */
 GrayString gray_string_format(GrayArena *arena, const char *fmt, ...);
 
+/* Null-terminate a GrayString into a caller-provided buffer.
+ * Truncates to buf_size-1 if needed. Returns buf for convenience. */
+static inline const char *gray_cstr(GrayString s, char *buf, size_t buf_size) {
+    size_t len = (size_t)s.len < buf_size - 1 ? (size_t)s.len : buf_size - 1;
+    memcpy(buf, s.data, len);
+    buf[len] = '\0';
+    return buf;
+}
+
 /* String comparison */
 static inline bool gray_string_eq(GrayString a, GrayString b) {
     if (a.len != b.len) return false;

--- a/grayc/src/stdlib/arrays.c
+++ b/grayc/src/stdlib/arrays.c
@@ -13,6 +13,11 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#define ARRAY_CHECK_ITER(arr) \
+    do { if ((arr)->iterating > 0) \
+        gray_panic_code("P0034", "cannot modify array during for_each iteration"); \
+    } while (0)
+
 /* === Modification === */
 
 void gray_arrays_append(GrayArena *arena, GrayArray *arr, const void *value) {
@@ -20,8 +25,7 @@ void gray_arrays_append(GrayArena *arena, GrayArray *arr, const void *value) {
 }
 
 void gray_arrays_insert_at(GrayArena *arena, GrayArray *arr, int32_t index, const void *value) {
-    if (arr->iterating > 0)
-        gray_panic_code("P0034", "cannot modify array during for_each iteration");
+    ARRAY_CHECK_ITER(arr);
     if (index < 0 || index > arr->len) {
         gray_panic_code("P0043",
             "arrays.insert_at: index %d is out of bounds for an array of length %d",
@@ -58,8 +62,7 @@ void gray_arrays_prepend(GrayArena *arena, GrayArray *arr, const void *value) {
 }
 
 void gray_arrays_remove_at(GrayArray *arr, int32_t index) {
-    if (arr->iterating > 0)
-        gray_panic_code("P0034", "cannot modify array during for_each iteration");
+    ARRAY_CHECK_ITER(arr);
     if (index < 0 || index >= arr->len)
         gray_panic_code("P0044",
             "arrays.remove_at: index %d is out of bounds for an array of length %d",
@@ -99,8 +102,7 @@ void gray_arrays_remove_str(GrayArray *arr, GrayString value) {
 }
 
 void gray_arrays_clear(GrayArray *arr) {
-    if (arr->iterating > 0)
-        gray_panic_code("P0034", "cannot modify array during for_each iteration");
+    ARRAY_CHECK_ITER(arr);
     arr->len = 0;
 }
 
@@ -126,8 +128,7 @@ void *gray_arrays_last_ptr(GrayArray *arr) {
 }
 
 void gray_arrays_remove_first_raw(GrayArray *arr, void *out) {
-    if (arr->iterating > 0)
-        gray_panic_code("P0034", "cannot modify array during for_each iteration");
+    ARRAY_CHECK_ITER(arr);
     if (arr->len == 0)
         gray_panic_code("P0047", "arrays.remove_first called on an empty array");
     memcpy(out, arr->data, arr->elem_size);
@@ -135,8 +136,7 @@ void gray_arrays_remove_first_raw(GrayArray *arr, void *out) {
 }
 
 void gray_arrays_remove_last_raw(GrayArray *arr, void *out) {
-    if (arr->iterating > 0)
-        gray_panic_code("P0034", "cannot modify array during for_each iteration");
+    ARRAY_CHECK_ITER(arr);
     if (arr->len == 0)
         gray_panic_code("P0048", "arrays.remove_last called on an empty array");
     memcpy(out, (char *)arr->data + (arr->len - 1) * arr->elem_size, arr->elem_size);
@@ -154,8 +154,7 @@ int64_t gray_arrays_get_last(GrayArray *arr) {
 }
 
 int64_t gray_arrays_remove_last(GrayArray *arr) {
-    if (arr->iterating > 0)
-        gray_panic_code("P0034", "cannot modify array during for_each iteration");
+    ARRAY_CHECK_ITER(arr);
     if (arr->len == 0) gray_panic_code("P0048", "arrays.remove_last called on an empty array");
     int64_t val = *(int64_t *)((char *)arr->data + (arr->len - 1) * arr->elem_size);
     arr->len--;
@@ -403,43 +402,37 @@ static int cmp_str_desc(const void *a, const void *b) {
 }
 
 void gray_arrays_sort_asc(GrayArray *arr) {
-    if (arr->iterating > 0)
-        gray_panic_code("P0034", "cannot modify array during for_each iteration");
+    ARRAY_CHECK_ITER(arr);
     if (arr->len <= 1) return;
     qsort(arr->data, (size_t)arr->len, (size_t)arr->elem_size, cmp_i64_asc);
 }
 
 void gray_arrays_sort_asc_float(GrayArray *arr) {
-    if (arr->iterating > 0)
-        gray_panic_code("P0034", "cannot modify array during for_each iteration");
+    ARRAY_CHECK_ITER(arr);
     if (arr->len <= 1) return;
     qsort(arr->data, (size_t)arr->len, (size_t)arr->elem_size, cmp_f64_asc);
 }
 
 void gray_arrays_sort_asc_str(GrayArray *arr) {
-    if (arr->iterating > 0)
-        gray_panic_code("P0034", "cannot modify array during for_each iteration");
+    ARRAY_CHECK_ITER(arr);
     if (arr->len <= 1) return;
     qsort(arr->data, (size_t)arr->len, (size_t)arr->elem_size, cmp_str_asc);
 }
 
 void gray_arrays_sort_desc(GrayArray *arr) {
-    if (arr->iterating > 0)
-        gray_panic_code("P0034", "cannot modify array during for_each iteration");
+    ARRAY_CHECK_ITER(arr);
     if (arr->len <= 1) return;
     qsort(arr->data, (size_t)arr->len, (size_t)arr->elem_size, cmp_i64_desc);
 }
 
 void gray_arrays_sort_desc_float(GrayArray *arr) {
-    if (arr->iterating > 0)
-        gray_panic_code("P0034", "cannot modify array during for_each iteration");
+    ARRAY_CHECK_ITER(arr);
     if (arr->len <= 1) return;
     qsort(arr->data, (size_t)arr->len, (size_t)arr->elem_size, cmp_f64_desc);
 }
 
 void gray_arrays_sort_desc_str(GrayArray *arr) {
-    if (arr->iterating > 0)
-        gray_panic_code("P0034", "cannot modify array during for_each iteration");
+    ARRAY_CHECK_ITER(arr);
     if (arr->len <= 1) return;
     qsort(arr->data, (size_t)arr->len, (size_t)arr->elem_size, cmp_str_desc);
 }

--- a/grayc/src/stdlib/binary.c
+++ b/grayc/src/stdlib/binary.c
@@ -29,74 +29,57 @@ static GrayArray make_bytes_reversed(GrayArena *arena, const void *data, int32_t
     return arr;
 }
 
-/* --- 8-bit --- */
+/* --- Codec macros for encode/decode generation --- */
+
+#define BINARY_ENCODE_LE(NAME, TYPE, SIZE)                                          \
+    GrayArray gray_binary_encode_##NAME##_le(GrayArena *arena, TYPE val) {           \
+        return make_bytes(arena, &val, SIZE);                                        \
+    }
+
+#define BINARY_ENCODE_BE(NAME, TYPE, SIZE)                                          \
+    GrayArray gray_binary_encode_##NAME##_be(GrayArena *arena, TYPE val) {           \
+        return make_bytes_reversed(arena, &val, SIZE);                               \
+    }
+
+#define BINARY_DECODE_LE(NAME, TYPE, SIZE)                                          \
+    TYPE gray_binary_decode_##NAME##_le(GrayArray *bytes) {                          \
+        TYPE v; memcpy(&v, bytes->data, SIZE); return v;                             \
+    }
+
+#define BINARY_DECODE_BE(NAME, TYPE, SIZE)                                          \
+    TYPE gray_binary_decode_##NAME##_be(GrayArray *bytes) {                          \
+        uint8_t *d = (uint8_t *)bytes->data;                                         \
+        uint8_t rev[SIZE];                                                           \
+        for (int32_t _i = 0; _i < SIZE; _i++) rev[_i] = d[SIZE - 1 - _i];          \
+        TYPE v; memcpy(&v, rev, SIZE); return v;                                     \
+    }
+
+#define BINARY_CODEC(NAME, TYPE, SIZE)                                              \
+    BINARY_ENCODE_LE(NAME, TYPE, SIZE)                                              \
+    BINARY_ENCODE_BE(NAME, TYPE, SIZE)                                              \
+    BINARY_DECODE_LE(NAME, TYPE, SIZE)                                              \
+    BINARY_DECODE_BE(NAME, TYPE, SIZE)
+
+/* --- 8-bit (no endianness) --- */
 GrayArray gray_binary_encode_i8(GrayArena *arena, int8_t val) { return make_bytes(arena, &val, 1); }
 GrayArray gray_binary_encode_u8(GrayArena *arena, uint8_t val) { return make_bytes(arena, &val, 1); }
 int8_t gray_binary_decode_i8(GrayArray *bytes) { return *(int8_t *)bytes->data; }
 uint8_t gray_binary_decode_u8(GrayArray *bytes) { return *(uint8_t *)bytes->data; }
 
-/* --- 16-bit signed --- */
-GrayArray gray_binary_encode_i16_le(GrayArena *arena, int16_t val) { return make_bytes(arena, &val, 2); }
-GrayArray gray_binary_encode_i16_be(GrayArena *arena, int16_t val) { return make_bytes_reversed(arena, &val, 2); }
-int16_t gray_binary_decode_i16_le(GrayArray *bytes) { int16_t v; memcpy(&v, bytes->data, 2); return v; }
-int16_t gray_binary_decode_i16_be(GrayArray *bytes) {
-    uint8_t *d = (uint8_t *)bytes->data;
-    return (int16_t)((d[0] << 8) | d[1]);
-}
+/* --- 16 through 64-bit integers + floats --- */
+BINARY_CODEC(i16, int16_t, 2)
+BINARY_CODEC(u16, uint16_t, 2)
+BINARY_CODEC(i32, int32_t, 4)
+BINARY_CODEC(u32, uint32_t, 4)
+BINARY_CODEC(i64, int64_t, 8)
+BINARY_CODEC(u64, uint64_t, 8)
+BINARY_CODEC(f32, float, 4)
+BINARY_CODEC(f64, double, 8)
 
-/* --- 16-bit unsigned --- */
-GrayArray gray_binary_encode_u16_le(GrayArena *arena, uint16_t val) { return make_bytes(arena, &val, 2); }
-GrayArray gray_binary_encode_u16_be(GrayArena *arena, uint16_t val) { return make_bytes_reversed(arena, &val, 2); }
-uint16_t gray_binary_decode_u16_le(GrayArray *bytes) { uint16_t v; memcpy(&v, bytes->data, 2); return v; }
-uint16_t gray_binary_decode_u16_be(GrayArray *bytes) {
-    uint8_t *d = (uint8_t *)bytes->data;
-    return (uint16_t)((d[0] << 8) | d[1]);
-}
-
-/* --- 32-bit signed --- */
-GrayArray gray_binary_encode_i32_le(GrayArena *arena, int32_t val) { return make_bytes(arena, &val, 4); }
-GrayArray gray_binary_encode_i32_be(GrayArena *arena, int32_t val) { return make_bytes_reversed(arena, &val, 4); }
-int32_t gray_binary_decode_i32_le(GrayArray *bytes) { int32_t v; memcpy(&v, bytes->data, 4); return v; }
-int32_t gray_binary_decode_i32_be(GrayArray *bytes) {
-    uint8_t *d = (uint8_t *)bytes->data;
-    return (int32_t)(((uint32_t)d[0] << 24) | ((uint32_t)d[1] << 16) | ((uint32_t)d[2] << 8) | d[3]);
-}
-
-/* --- 32-bit unsigned --- */
-GrayArray gray_binary_encode_u32_le(GrayArena *arena, uint32_t val) { return make_bytes(arena, &val, 4); }
-GrayArray gray_binary_encode_u32_be(GrayArena *arena, uint32_t val) { return make_bytes_reversed(arena, &val, 4); }
-uint32_t gray_binary_decode_u32_le(GrayArray *bytes) { uint32_t v; memcpy(&v, bytes->data, 4); return v; }
-uint32_t gray_binary_decode_u32_be(GrayArray *bytes) {
-    uint8_t *d = (uint8_t *)bytes->data;
-    return ((uint32_t)d[0] << 24) | ((uint32_t)d[1] << 16) | ((uint32_t)d[2] << 8) | d[3];
-}
-
-/* --- 64-bit signed --- */
-GrayArray gray_binary_encode_i64_le(GrayArena *arena, int64_t val) { return make_bytes(arena, &val, 8); }
-GrayArray gray_binary_encode_i64_be(GrayArena *arena, int64_t val) { return make_bytes_reversed(arena, &val, 8); }
-int64_t gray_binary_decode_i64_le(GrayArray *bytes) { int64_t v; memcpy(&v, bytes->data, 8); return v; }
-int64_t gray_binary_decode_i64_be(GrayArray *bytes) {
-    uint8_t *d = (uint8_t *)bytes->data;
-    int64_t v = 0;
-    for (int i = 0; i < 8; i++) v = (v << 8) | d[i];
-    return v;
-}
-
-/* --- 64-bit unsigned --- */
-GrayArray gray_binary_encode_u64_le(GrayArena *arena, uint64_t val) { return make_bytes(arena, &val, 8); }
-GrayArray gray_binary_encode_u64_be(GrayArena *arena, uint64_t val) { return make_bytes_reversed(arena, &val, 8); }
-uint64_t gray_binary_decode_u64_le(GrayArray *bytes) { uint64_t v; memcpy(&v, bytes->data, 8); return v; }
-uint64_t gray_binary_decode_u64_be(GrayArray *bytes) {
-    uint8_t *d = (uint8_t *)bytes->data;
-    uint64_t v = 0;
-    for (int i = 0; i < 8; i++) v = (v << 8) | d[i];
-    return v;
-}
-
-/* --- 128-bit --- */
-GrayArray gray_binary_encode_i128_le(GrayArena *arena, gray_i128 val) { return make_bytes(arena, &val, 16); }
-GrayArray gray_binary_encode_i128_be(GrayArena *arena, gray_i128 val) { return make_bytes_reversed(arena, &val, 16); }
-gray_i128 gray_binary_decode_i128_le(GrayArray *bytes) { gray_i128 v; memcpy(&v, bytes->data, 16); return v; }
+/* --- 128-bit (custom BE decode for multi-limb struct layout) --- */
+BINARY_ENCODE_LE(i128, gray_i128, 16)
+BINARY_ENCODE_BE(i128, gray_i128, 16)
+BINARY_DECODE_LE(i128, gray_i128, 16)
 gray_i128 gray_binary_decode_i128_be(GrayArray *bytes) {
     uint8_t *d = (uint8_t *)bytes->data;
     gray_i128 v;
@@ -108,9 +91,9 @@ gray_i128 gray_binary_decode_i128_be(GrayArray *bytes) {
     return v;
 }
 
-GrayArray gray_binary_encode_u128_le(GrayArena *arena, gray_u128 val) { return make_bytes(arena, &val, 16); }
-GrayArray gray_binary_encode_u128_be(GrayArena *arena, gray_u128 val) { return make_bytes_reversed(arena, &val, 16); }
-gray_u128 gray_binary_decode_u128_le(GrayArray *bytes) { gray_u128 v; memcpy(&v, bytes->data, 16); return v; }
+BINARY_ENCODE_LE(u128, gray_u128, 16)
+BINARY_ENCODE_BE(u128, gray_u128, 16)
+BINARY_DECODE_LE(u128, gray_u128, 16)
 gray_u128 gray_binary_decode_u128_be(GrayArray *bytes) {
     uint8_t *d = (uint8_t *)bytes->data;
     gray_u128 v;
@@ -122,10 +105,10 @@ gray_u128 gray_binary_decode_u128_be(GrayArray *bytes) {
     return v;
 }
 
-/* --- 256-bit --- */
-GrayArray gray_binary_encode_i256_le(GrayArena *arena, gray_i256 val) { return make_bytes(arena, &val, 32); }
-GrayArray gray_binary_encode_i256_be(GrayArena *arena, gray_i256 val) { return make_bytes_reversed(arena, &val, 32); }
-gray_i256 gray_binary_decode_i256_le(GrayArray *bytes) { gray_i256 v; memcpy(&v, bytes->data, 32); return v; }
+/* --- 256-bit (custom BE decode for 4-limb struct layout) --- */
+BINARY_ENCODE_LE(i256, gray_i256, 32)
+BINARY_ENCODE_BE(i256, gray_i256, 32)
+BINARY_DECODE_LE(i256, gray_i256, 32)
 gray_i256 gray_binary_decode_i256_be(GrayArray *bytes) {
     uint8_t *d = (uint8_t *)bytes->data;
     gray_i256 v;
@@ -137,9 +120,9 @@ gray_i256 gray_binary_decode_i256_be(GrayArray *bytes) {
     return v;
 }
 
-GrayArray gray_binary_encode_u256_le(GrayArena *arena, gray_u256 val) { return make_bytes(arena, &val, 32); }
-GrayArray gray_binary_encode_u256_be(GrayArena *arena, gray_u256 val) { return make_bytes_reversed(arena, &val, 32); }
-gray_u256 gray_binary_decode_u256_le(GrayArray *bytes) { gray_u256 v; memcpy(&v, bytes->data, 32); return v; }
+BINARY_ENCODE_LE(u256, gray_u256, 32)
+BINARY_ENCODE_BE(u256, gray_u256, 32)
+BINARY_DECODE_LE(u256, gray_u256, 32)
 gray_u256 gray_binary_decode_u256_be(GrayArray *bytes) {
     uint8_t *d = (uint8_t *)bytes->data;
     gray_u256 v;
@@ -151,21 +134,8 @@ gray_u256 gray_binary_decode_u256_be(GrayArray *bytes) {
     return v;
 }
 
-/* --- Float --- */
-GrayArray gray_binary_encode_f32_le(GrayArena *arena, float val) { return make_bytes(arena, &val, 4); }
-GrayArray gray_binary_encode_f32_be(GrayArena *arena, float val) { return make_bytes_reversed(arena, &val, 4); }
-float gray_binary_decode_f32_le(GrayArray *bytes) { float v; memcpy(&v, bytes->data, 4); return v; }
-float gray_binary_decode_f32_be(GrayArray *bytes) {
-    uint8_t *d = (uint8_t *)bytes->data;
-    uint8_t reversed[4] = {d[3], d[2], d[1], d[0]};
-    float v; memcpy(&v, reversed, 4); return v;
-}
-
-GrayArray gray_binary_encode_f64_le(GrayArena *arena, double val) { return make_bytes(arena, &val, 8); }
-GrayArray gray_binary_encode_f64_be(GrayArena *arena, double val) { return make_bytes_reversed(arena, &val, 8); }
-double gray_binary_decode_f64_le(GrayArray *bytes) { double v; memcpy(&v, bytes->data, 8); return v; }
-double gray_binary_decode_f64_be(GrayArray *bytes) {
-    uint8_t *d = (uint8_t *)bytes->data;
-    uint8_t reversed[8] = {d[7], d[6], d[5], d[4], d[3], d[2], d[1], d[0]};
-    double v; memcpy(&v, reversed, 8); return v;
-}
+#undef BINARY_ENCODE_LE
+#undef BINARY_ENCODE_BE
+#undef BINARY_DECODE_LE
+#undef BINARY_DECODE_BE
+#undef BINARY_CODEC

--- a/grayc/src/stdlib/builtins.c
+++ b/grayc/src/stdlib/builtins.c
@@ -46,23 +46,45 @@ static int fmt_shortest_float(char *buf, size_t buffer_size, double v) {
     return n;
 }
 
+/* Encode Unicode codepoint to UTF-8; returns byte count (1-4). */
+static int cp_to_utf8(int32_t cp, char *out) {
+    if (cp < 0x80)   { out[0] = (char)cp; return 1; }
+    if (cp < 0x800)  { out[0] = (char)(0xC0|(cp>>6)); out[1] = (char)(0x80|(cp&0x3F)); return 2; }
+    if (cp < 0x10000){ out[0] = (char)(0xE0|(cp>>12)); out[1] = (char)(0x80|((cp>>6)&0x3F)); out[2] = (char)(0x80|(cp&0x3F)); return 3; }
+    out[0]=(char)(0xF0|(cp>>18)); out[1]=(char)(0x80|((cp>>12)&0x3F)); out[2]=(char)(0x80|((cp>>6)&0x3F)); out[3]=(char)(0x80|(cp&0x3F)); return 4;
+}
+
+/* Decode next UTF-8 character; returns bytes consumed (1-4).
+   Writes decoded codepoint to *cp_out (0xFFFD on invalid input). */
+static int utf8_next(const uint8_t *p, const uint8_t *end, int32_t *cp_out) {
+    uint8_t b = *p;
+    int32_t cp;
+    int bytes;
+    if (b < 0x80) {
+        *cp_out = b; return 1;
+    } else if ((b & 0xE0) == 0xC0) {
+        cp = b & 0x1F; bytes = 2;
+    } else if ((b & 0xF0) == 0xE0) {
+        cp = b & 0x0F; bytes = 3;
+    } else if ((b & 0xF8) == 0xF0) {
+        cp = b & 0x07; bytes = 4;
+    } else {
+        *cp_out = 0xFFFD; return 1;
+    }
+    if (p + bytes > end) { *cp_out = 0xFFFD; return 1; }
+    for (int i = 1; i < bytes; i++) {
+        if ((p[i] & 0xC0) != 0x80) { *cp_out = 0xFFFD; return 1; }
+        cp = (cp << 6) | (p[i] & 0x3F);
+    }
+    *cp_out = cp;
+    return bytes;
+}
+
 /* Write a Unicode code point as UTF-8 to a FILE stream */
 static void fput_utf8(int32_t c, FILE *f) {
-    if (c < 0x80) {
-        fputc(c, f);
-    } else if (c < 0x800) {
-        fputc(0xC0 | (c >> 6), f);
-        fputc(0x80 | (c & 0x3F), f);
-    } else if (c < 0x10000) {
-        fputc(0xE0 | (c >> 12), f);
-        fputc(0x80 | ((c >> 6) & 0x3F), f);
-        fputc(0x80 | (c & 0x3F), f);
-    } else if (c < 0x110000) {
-        fputc(0xF0 | (c >> 18), f);
-        fputc(0x80 | ((c >> 12) & 0x3F), f);
-        fputc(0x80 | ((c >> 6) & 0x3F), f);
-        fputc(0x80 | (c & 0x3F), f);
-    }
+    char buf[4];
+    int len = cp_to_utf8(c, buf);
+    fwrite(buf, 1, (size_t)len, f);
 }
 
 /* --- println --- */
@@ -331,14 +353,6 @@ double gray_builtin_string_to_float(GrayString s) {
 
 /* --- composite to_string --- */
 
-/* Encode Unicode codepoint to UTF-8; returns byte count (1-4). */
-static int cp_to_utf8(int32_t cp, char *out) {
-    if (cp < 0x80)   { out[0] = (char)cp; return 1; }
-    if (cp < 0x800)  { out[0] = (char)(0xC0|(cp>>6)); out[1] = (char)(0x80|(cp&0x3F)); return 2; }
-    if (cp < 0x10000){ out[0] = (char)(0xE0|(cp>>12)); out[1] = (char)(0x80|((cp>>6)&0x3F)); out[2] = (char)(0x80|(cp&0x3F)); return 3; }
-    out[0]=(char)(0xF0|(cp>>18)); out[1]=(char)(0x80|((cp>>12)&0x3F)); out[2]=(char)(0x80|((cp>>6)&0x3F)); out[3]=(char)(0x80|(cp&0x3F)); return 4;
-}
-
 GrayString gray_builtin_array_to_string(GrayArena *arena, GrayArray *arr, int elem_kind) {
     char buf[GRAY_TOSTRING_BUF_SIZE];
     int pos = 0;
@@ -402,31 +416,7 @@ int32_t gray_builtin_to_char(GrayString s, int64_t index, const char *file, int 
     int64_t cp_idx = 0;
     while (p < end) {
         int32_t cp;
-        int bytes;
-        uint8_t b = *p;
-        if (b < 0x80) {
-            cp = b; bytes = 1;
-        } else if ((b & 0xE0) == 0xC0) {
-            cp = b & 0x1F; bytes = 2;
-        } else if ((b & 0xF0) == 0xE0) {
-            cp = b & 0x0F; bytes = 3;
-        } else if ((b & 0xF8) == 0xF0) {
-            cp = b & 0x07; bytes = 4;
-        } else {
-            cp = 0xFFFD; bytes = 1; /* replacement character for invalid lead byte */
-        }
-        /* Validate we have enough continuation bytes */
-        if (p + bytes > end) {
-            cp = 0xFFFD; bytes = 1;
-        } else {
-            for (int i = 1; i < bytes; i++) {
-                if ((p[i] & 0xC0) != 0x80) {
-                    cp = 0xFFFD; bytes = 1;
-                    break;
-                }
-                cp = (cp << 6) | (p[i] & 0x3F);
-            }
-        }
+        int bytes = utf8_next(p, end, &cp);
         if (cp_idx == index) return cp;
         p += bytes;
         cp_idx++;
@@ -441,13 +431,8 @@ int64_t gray_builtin_char_count(GrayString s) {
     const uint8_t *end = p + s.len;
     int64_t count = 0;
     while (p < end) {
-        uint8_t b = *p;
-        if (b < 0x80) p += 1;
-        else if ((b & 0xE0) == 0xC0) p += 2;
-        else if ((b & 0xF0) == 0xE0) p += 3;
-        else if ((b & 0xF8) == 0xF0) p += 4;
-        else p += 1; /* invalid lead byte, skip one */
-        if (p > end) p = end; /* clamp if truncated */
+        int32_t cp;
+        p += utf8_next(p, end, &cp);
         count++;
     }
     return count;
@@ -455,28 +440,12 @@ int64_t gray_builtin_char_count(GrayString s) {
 
 GrayString gray_builtin_char_to_utf8(GrayArena *arena, int32_t cp) {
     char buf[4];
-    int len = 0;
-    if (cp < 0x80) {
-        buf[0] = (char)cp; len = 1;
-    } else if (cp < 0x800) {
-        buf[0] = (char)(0xC0 | (cp >> 6));
-        buf[1] = (char)(0x80 | (cp & 0x3F));
-        len = 2;
-    } else if (cp < 0x10000) {
-        buf[0] = (char)(0xE0 | (cp >> 12));
-        buf[1] = (char)(0x80 | ((cp >> 6) & 0x3F));
-        buf[2] = (char)(0x80 | (cp & 0x3F));
-        len = 3;
-    } else if (cp < 0x110000) {
-        buf[0] = (char)(0xF0 | (cp >> 18));
-        buf[1] = (char)(0x80 | ((cp >> 12) & 0x3F));
-        buf[2] = (char)(0x80 | ((cp >> 6) & 0x3F));
-        buf[3] = (char)(0x80 | (cp & 0x3F));
-        len = 4;
-    } else {
+    int len;
+    if (cp >= 0x110000) {
         /* Invalid codepoint — replacement character U+FFFD */
-        buf[0] = (char)0xEF; buf[1] = (char)0xBF; buf[2] = (char)0xBD;
-        len = 3;
+        len = cp_to_utf8(0xFFFD, buf);
+    } else {
+        len = cp_to_utf8(cp, buf);
     }
     return gray_string_new(arena, buf, (int32_t)len);
 }

--- a/grayc/src/stdlib/builtins.c
+++ b/grayc/src/stdlib/builtins.c
@@ -398,6 +398,10 @@ GrayString gray_builtin_array_to_string(GrayArena *arena, GrayArray *arr, int el
             }
             break;
         }
+        case 7:
+            pos += snprintf(buf + pos, sizeof(buf) - pos, "%d",
+                GRAY_ARRAY_GET(*arr, int, i));
+            break;
         }
     }
     buf[pos++] = '}';
@@ -490,6 +494,7 @@ GrayString gray_builtin_map_to_string(GrayArena *arena, GrayMap *m, int val_kind
             }
             break;
         }
+        case 7: pos += snprintf(buf + pos, sizeof(buf) - pos, "%d", *(int *)vp); break;
         }
     }
     if (m->order_len == 0) { buf[pos++] = ':'; }

--- a/grayc/src/stdlib/builtins.c
+++ b/grayc/src/stdlib/builtins.c
@@ -87,135 +87,62 @@ static void fput_utf8(int32_t c, FILE *f) {
     fwrite(buf, 1, (size_t)len, f);
 }
 
-/* --- println --- */
+/* --- Core print helpers (one per type) --- */
 
-void gray_builtin_println_str(GrayString s) {
-    fwrite(s.data, 1, (size_t)s.len, stdout);
-    putchar('\n');
+static void print_core_str(GrayString s, FILE *stream, bool newline) {
+    fwrite(s.data, 1, (size_t)s.len, stream);
+    if (newline) fputc('\n', stream);
 }
 
-void gray_builtin_println_int(int64_t v) {
-    printf("%" PRId64 "\n", v);
+static void print_core_int(int64_t v, FILE *stream, bool newline) {
+    fprintf(stream, "%" PRId64, v);
+    if (newline) fputc('\n', stream);
 }
 
-void gray_builtin_println_uint(uint64_t v) {
-    printf("%" PRIu64 "\n", v);
+static void print_core_uint(uint64_t v, FILE *stream, bool newline) {
+    fprintf(stream, "%" PRIu64, v);
+    if (newline) fputc('\n', stream);
 }
 
-void gray_builtin_println_float(double v) {
+static void print_core_float(double v, FILE *stream, bool newline) {
     char buf[GRAY_FLOAT_STR_BUF];
     fmt_shortest_float(buf, sizeof(buf), v);
-    printf("%s\n", buf);
+    fprintf(stream, "%s", buf);
+    if (newline) fputc('\n', stream);
 }
 
-void gray_builtin_println_bool(bool v) {
-    printf("%s\n", v ? "true" : "false");
+static void print_core_bool(bool v, FILE *stream, bool newline) {
+    fprintf(stream, "%s", v ? "true" : "false");
+    if (newline) fputc('\n', stream);
 }
 
-void gray_builtin_println_char(int32_t c) {
-    fput_utf8(c, stdout);
-    putchar('\n');
+static void print_core_char(int32_t c, FILE *stream, bool newline) {
+    fput_utf8(c, stream);
+    if (newline) fputc('\n', stream);
 }
 
-void gray_builtin_println_addr(uintptr_t v) {
-    printf("0x%" PRIxPTR "\n", v);
+static void print_core_addr(uintptr_t v, FILE *stream, bool newline) {
+    fprintf(stream, "0x%" PRIxPTR, v);
+    if (newline) fputc('\n', stream);
 }
 
-/* --- print --- */
+/* --- Public print/println/eprint/eprintln wrappers --- */
 
-void gray_builtin_print_str(GrayString s) {
-    fwrite(s.data, 1, (size_t)s.len, stdout);
-}
+#define PRINT_FAMILY(SUFFIX, CTYPE)                                                         \
+    void gray_builtin_println_##SUFFIX(CTYPE v)  { print_core_##SUFFIX(v, stdout, true);  } \
+    void gray_builtin_print_##SUFFIX(CTYPE v)    { print_core_##SUFFIX(v, stdout, false); } \
+    void gray_builtin_eprintln_##SUFFIX(CTYPE v) { print_core_##SUFFIX(v, stderr, true);  } \
+    void gray_builtin_eprint_##SUFFIX(CTYPE v)   { print_core_##SUFFIX(v, stderr, false); }
 
-void gray_builtin_print_int(int64_t v) {
-    printf("%" PRId64, v);
-}
+PRINT_FAMILY(str,   GrayString)
+PRINT_FAMILY(int,   int64_t)
+PRINT_FAMILY(uint,  uint64_t)
+PRINT_FAMILY(float, double)
+PRINT_FAMILY(bool,  bool)
+PRINT_FAMILY(char,  int32_t)
+PRINT_FAMILY(addr,  uintptr_t)
 
-void gray_builtin_print_uint(uint64_t v) {
-    printf("%" PRIu64, v);
-}
-
-void gray_builtin_print_float(double v) {
-    char buf[GRAY_FLOAT_STR_BUF];
-    fmt_shortest_float(buf, sizeof(buf), v);
-    printf("%s", buf);
-}
-
-void gray_builtin_print_bool(bool v) {
-    printf("%s", v ? "true" : "false");
-}
-
-void gray_builtin_print_char(int32_t c) {
-    fput_utf8(c, stdout);
-}
-
-void gray_builtin_print_addr(uintptr_t v) {
-    printf("0x%" PRIxPTR, v);
-}
-
-/* --- eprintln / eprint --- */
-
-void gray_builtin_eprintln_str(GrayString s) {
-    fwrite(s.data, 1, (size_t)s.len, stderr);
-    fputc('\n', stderr);
-}
-
-void gray_builtin_eprintln_int(int64_t v) {
-    fprintf(stderr, "%" PRId64 "\n", v);
-}
-
-void gray_builtin_eprintln_uint(uint64_t v) {
-    fprintf(stderr, "%" PRIu64 "\n", v);
-}
-
-void gray_builtin_eprintln_char(int32_t c) {
-    fput_utf8(c, stderr);
-    fputc('\n', stderr);
-}
-
-void gray_builtin_eprintln_float(double v) {
-    char buf[GRAY_FLOAT_STR_BUF];
-    fmt_shortest_float(buf, sizeof(buf), v);
-    fprintf(stderr, "%s\n", buf);
-}
-
-void gray_builtin_eprintln_bool(bool v) {
-    fprintf(stderr, "%s\n", v ? "true" : "false");
-}
-
-void gray_builtin_eprintln_addr(uintptr_t v) {
-    fprintf(stderr, "0x%" PRIxPTR "\n", v);
-}
-
-void gray_builtin_eprint_str(GrayString s) {
-    fwrite(s.data, 1, (size_t)s.len, stderr);
-}
-
-void gray_builtin_eprint_int(int64_t v) {
-    fprintf(stderr, "%" PRId64, v);
-}
-
-void gray_builtin_eprint_uint(uint64_t v) {
-    fprintf(stderr, "%" PRIu64, v);
-}
-
-void gray_builtin_eprint_float(double v) {
-    char buf[GRAY_FLOAT_STR_BUF];
-    fmt_shortest_float(buf, sizeof(buf), v);
-    fprintf(stderr, "%s", buf);
-}
-
-void gray_builtin_eprint_bool(bool v) {
-    fprintf(stderr, "%s", v ? "true" : "false");
-}
-
-void gray_builtin_eprint_char(int32_t c) {
-    fput_utf8(c, stderr);
-}
-
-void gray_builtin_eprint_addr(uintptr_t v) {
-    fprintf(stderr, "0x%" PRIxPTR, v);
-}
+#undef PRINT_FAMILY
 
 /* --- input --- */
 

--- a/grayc/src/stdlib/csv.c
+++ b/grayc/src/stdlib/csv.c
@@ -33,6 +33,19 @@ GrayArray gray_csv_parse(GrayArena *arena, GrayString csv_string) {
                 }
                 field_length = (int32_t)(s - field_start);
                 if (s < end) s++; /* skip closing quote */
+
+                /* RFC 4180 §2.7: unescape doubled quotes ("") to single (") */
+                if (memchr(field_start, '"', (size_t)field_length)) {
+                    char *buf = gray_arena_alloc(arena, (size_t)field_length);
+                    int32_t out = 0;
+                    for (int32_t k = 0; k < field_length; k++) {
+                        buf[out++] = field_start[k];
+                        if (field_start[k] == '"' && k + 1 < field_length && field_start[k + 1] == '"')
+                            k++; /* skip second quote of pair */
+                    }
+                    field_start = buf;
+                    field_length = out;
+                }
             } else {
                 /* Unquoted field */
                 field_start = s;

--- a/grayc/src/stdlib/http.c
+++ b/grayc/src/stdlib/http.c
@@ -23,13 +23,6 @@
 #define GRAY_HTTP_RESP_BUF        1048576
 #define GRAY_HTTP_MIN_RESP_LEN    12
 
-/* Helper: null-terminate an GrayString */
-static const char *http_cstr(GrayString s, char *buf, size_t buffer_size) {
-    size_t len = (size_t)s.len < buffer_size - 1 ? (size_t)s.len : buffer_size - 1;
-    memcpy(buf, s.data, len);
-    buf[len] = '\0';
-    return buf;
-}
 
 /* Parse a URL into host, port, and path components */
 static bool parse_url(const char *url, char *host, size_t host_sz,
@@ -154,7 +147,7 @@ static GrayHttpResponse do_request(GrayArena *arena, const char *method,
     err_resp.headers = gray_map_new(arena, sizeof(GrayString), sizeof(GrayString), 4);
 
     char url_buf[GRAY_HTTP_URL_BUF];
-    http_cstr(url, url_buf, sizeof(url_buf));
+    gray_cstr(url, url_buf, sizeof(url_buf));
 
     if (strncmp(url_buf, "https://", 8) == 0) {
         const char *detail = "https:// is not supported; use http://";

--- a/grayc/src/stdlib/net.c
+++ b/grayc/src/stdlib/net.c
@@ -24,20 +24,13 @@
 #define GRAY_NET_MAX_RECV_BUF     1048576
 #define GRAY_NET_LISTEN_BACKLOG   128
 
-/* Helper: null-terminate an GrayString */
-static const char *net_cstr(GrayString s, char *buf, size_t buffer_size) {
-    size_t len = (size_t)s.len < buffer_size - 1 ? (size_t)s.len : buffer_size - 1;
-    memcpy(buf, s.data, len);
-    buf[len] = '\0';
-    return buf;
-}
 
 GraySocket gray_net_dial(GrayArena *arena, GrayString host, int64_t port) {
     (void)arena;
     GraySocket sock = {-1};
 
     char host_buf[GRAY_NET_HOST_BUF];
-    net_cstr(host, host_buf, sizeof(host_buf));
+    gray_cstr(host, host_buf, sizeof(host_buf));
 
     /* Resolve hostname */
     struct addrinfo hints, *res;
@@ -150,7 +143,7 @@ void gray_net_set_timeout(GraySocket sock, int64_t milliseconds) {
 
 GrayString gray_net_resolve(GrayArena *arena, GrayString hostname) {
     char host_buf[GRAY_NET_HOST_BUF];
-    net_cstr(hostname, host_buf, sizeof(host_buf));
+    gray_cstr(hostname, host_buf, sizeof(host_buf));
 
     struct addrinfo hints, *res;
     memset(&hints, 0, sizeof(hints));
@@ -194,7 +187,7 @@ GraySocket gray_net_listen_host(GrayArena *arena, GrayString host, int64_t port)
     setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
 
     char host_buf[GRAY_NET_HOST_BUF];
-    net_cstr(host, host_buf, sizeof(host_buf));
+    gray_cstr(host, host_buf, sizeof(host_buf));
 
     struct sockaddr_in addr;
     memset(&addr, 0, sizeof(addr));

--- a/grayc/src/stdlib/regex.c
+++ b/grayc/src/stdlib/regex.c
@@ -19,21 +19,9 @@
 /* Helper: compile pattern into a null-terminated C string and regex_t.
  * Returns 0 on success, non-zero on error. Caller must regfree on success. */
 static int compile_pattern(GrayString pattern, regex_t *re, int flags) {
-    /* Null-terminate the pattern */
     char pat_buf[GRAY_REGEX_PAT_BUF];
-    int pattern_length = pattern.len < (int32_t)sizeof(pat_buf) - 1 ? pattern.len : (int32_t)sizeof(pat_buf) - 1;
-    memcpy(pat_buf, pattern.data, (size_t)pattern_length);
-    pat_buf[pattern_length] = '\0';
-
+    gray_cstr(pattern, pat_buf, sizeof(pat_buf));
     return regcomp(re, pat_buf, flags | REG_EXTENDED);
-}
-
-/* Helper: null-terminate an GrayString into a buffer */
-static const char *to_cstr(GrayString s, char *buf, size_t buffer_size) {
-    size_t len = (size_t)s.len < buffer_size - 1 ? (size_t)s.len : buffer_size - 1;
-    memcpy(buf, s.data, len);
-    buf[len] = '\0';
-    return buf;
 }
 
 bool gray_regex_is_valid(GrayString pattern) {
@@ -48,7 +36,7 @@ bool gray_regex_match(GrayString pattern, GrayString text) {
     if (compile_pattern(pattern, &re, REG_NOSUB) != 0) return false;
 
     char txt_buf[GRAY_REGEX_TXT_BUF];
-    to_cstr(text, txt_buf, sizeof(txt_buf));
+    gray_cstr(text, txt_buf, sizeof(txt_buf));
 
     int result = regexec(&re, txt_buf, 0, NULL, 0);
     regfree(&re);
@@ -62,7 +50,7 @@ GrayString gray_regex_find(GrayArena *arena, GrayString pattern, GrayString text
     }
 
     char txt_buf[GRAY_REGEX_TXT_BUF];
-    to_cstr(text, txt_buf, sizeof(txt_buf));
+    gray_cstr(text, txt_buf, sizeof(txt_buf));
 
     regmatch_t match;
     if (regexec(&re, txt_buf, 1, &match, 0) != 0) {
@@ -82,7 +70,7 @@ GrayArray gray_regex_find_all(GrayArena *arena, GrayString pattern, GrayString t
     if (compile_pattern(pattern, &re, 0) != 0) return arr;
 
     char txt_buf[GRAY_REGEX_TXT_BUF];
-    to_cstr(text, txt_buf, sizeof(txt_buf));
+    gray_cstr(text, txt_buf, sizeof(txt_buf));
 
     const char *cursor = txt_buf;
     regmatch_t match;
@@ -110,10 +98,10 @@ GrayString gray_regex_replace(GrayArena *arena, GrayString pattern, GrayString t
     }
 
     char txt_buf[GRAY_REGEX_TXT_BUF];
-    to_cstr(text, txt_buf, sizeof(txt_buf));
+    gray_cstr(text, txt_buf, sizeof(txt_buf));
 
     char repl_buf[GRAY_REGEX_PAT_BUF];
-    to_cstr(replacement, repl_buf, sizeof(repl_buf));
+    gray_cstr(replacement, repl_buf, sizeof(repl_buf));
     int repl_len = (int)strlen(repl_buf);
 
     /* First pass: compute exact output size */
@@ -178,7 +166,7 @@ GrayArray gray_regex_split(GrayArena *arena, GrayString pattern, GrayString text
     }
 
     char txt_buf[GRAY_REGEX_TXT_BUF];
-    to_cstr(text, txt_buf, sizeof(txt_buf));
+    gray_cstr(text, txt_buf, sizeof(txt_buf));
 
     const char *cursor = txt_buf;
     regmatch_t match;

--- a/grayc/src/stdlib/sqlite.c
+++ b/grayc/src/stdlib/sqlite.c
@@ -41,6 +41,63 @@ bool gray_sqlite_exec(GraySqlite *db, GrayString sql) {
     return return_code == SQLITE_OK;
 }
 
+/* Bind all parameters from a [string] array to a prepared statement. */
+static int bind_string_params(sqlite3_stmt *stmt, GrayArray params) {
+    for (int32_t i = 0; i < params.len; i++) {
+        GrayString *s = (GrayString *)((char *)params.data + i * params.elem_size);
+        int rc = sqlite3_bind_text(stmt, i + 1, s->data, s->len, SQLITE_STATIC);
+        if (rc != SQLITE_OK) return rc;
+    }
+    return SQLITE_OK;
+}
+
+bool gray_sqlite_exec_params(GraySqlite *db, GrayString sql, GrayArray params) {
+    if (!db || !db->handle) return false;
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2((sqlite3 *)db->handle, sql.data, sql.len, &stmt, NULL);
+    if (rc != SQLITE_OK || !stmt) return false;
+    rc = bind_string_params(stmt, params);
+    if (rc != SQLITE_OK) { sqlite3_finalize(stmt); return false; }
+    rc = sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    return rc == SQLITE_DONE;
+}
+
+GrayArray gray_sqlite_query_params(GrayArena *arena, GraySqlite *db, GrayString sql, GrayArray params) {
+    GrayArray rows = gray_array_new(arena, sizeof(GrayMap), 8);
+    if (!db || !db->handle) return rows;
+
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2((sqlite3 *)db->handle, sql.data, sql.len, &stmt, NULL);
+    if (rc != SQLITE_OK || !stmt) return rows;
+
+    rc = bind_string_params(stmt, params);
+    if (rc != SQLITE_OK) { sqlite3_finalize(stmt); return rows; }
+
+    int col_count = sqlite3_column_count(stmt);
+
+    while (sqlite3_step(stmt) == SQLITE_ROW) {
+        GrayMap row = gray_map_new(arena, sizeof(GrayString), sizeof(GrayString), col_count * 2);
+        for (int i = 0; i < col_count; i++) {
+            const char *col_name = sqlite3_column_name(stmt, i);
+            GrayString key = gray_string_new(arena, col_name, (int32_t)strlen(col_name));
+
+            const char *val_text = (const char *)sqlite3_column_text(stmt, i);
+            GrayString val;
+            if (val_text) {
+                val = gray_string_new(arena, val_text, (int32_t)strlen(val_text));
+            } else {
+                val = gray_string_lit("");
+            }
+            GRAY_MAP_SET(arena, &row, &key, &val);
+        }
+        GRAY_ARRAY_PUSH(arena, &rows, &row);
+    }
+
+    sqlite3_finalize(stmt);
+    return rows;
+}
+
 GrayArray gray_sqlite_query(GrayArena *arena, GraySqlite *db, GrayString sql) {
     GrayArray rows = gray_array_new(arena, sizeof(GrayMap), 8);
     if (!db || !db->handle) return rows;
@@ -111,6 +168,42 @@ GrayResult_bool gray_sqlite_exec_result(GrayArena *arena, GraySqlite *db, GraySt
     return r;
 }
 
+GrayResult_bool gray_sqlite_exec_params_result(GrayArena *arena, GraySqlite *db, GrayString sql, GrayArray params) {
+    GrayResult_bool r;
+    if (!db || !db->handle) {
+        r.v0 = false;
+        r.v1 = gray_error_new(arena, gray_string_format(arena, "database handle is nil"));
+        return r;
+    }
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2((sqlite3 *)db->handle, sql.data, sql.len, &stmt, NULL);
+    if (rc != SQLITE_OK || !stmt) {
+        const char *errmsg = sqlite3_errmsg((sqlite3 *)db->handle);
+        r.v0 = false;
+        r.v1 = gray_error_new(arena, gray_string_format(arena, "exec_params failed: %s", errmsg ? errmsg : "unknown error"));
+        return r;
+    }
+    rc = bind_string_params(stmt, params);
+    if (rc != SQLITE_OK) {
+        const char *errmsg = sqlite3_errmsg((sqlite3 *)db->handle);
+        sqlite3_finalize(stmt);
+        r.v0 = false;
+        r.v1 = gray_error_new(arena, gray_string_format(arena, "exec_params bind failed: %s", errmsg ? errmsg : "unknown error"));
+        return r;
+    }
+    rc = sqlite3_step(stmt);
+    sqlite3_finalize(stmt);
+    if (rc != SQLITE_DONE) {
+        const char *errmsg = sqlite3_errmsg((sqlite3 *)db->handle);
+        r.v0 = false;
+        r.v1 = gray_error_new(arena, gray_string_format(arena, "exec_params failed: %s", errmsg ? errmsg : "unknown error"));
+    } else {
+        r.v0 = true;
+        r.v1 = NULL;
+    }
+    return r;
+}
+
 GrayResult_array gray_sqlite_query_result(GrayArena *arena, GraySqlite *db, GrayString sql) {
     GrayResult_array r;
     if (!db || !db->handle) {
@@ -128,6 +221,27 @@ GrayResult_array gray_sqlite_query_result(GrayArena *arena, GraySqlite *db, Gray
     }
     sqlite3_finalize(stmt);
     r.v0 = gray_sqlite_query(arena, db, sql);
+    r.v1 = NULL;
+    return r;
+}
+
+GrayResult_array gray_sqlite_query_params_result(GrayArena *arena, GraySqlite *db, GrayString sql, GrayArray params) {
+    GrayResult_array r;
+    if (!db || !db->handle) {
+        r.v0 = gray_array_new(arena, sizeof(GrayMap), 0);
+        r.v1 = gray_error_new(arena, gray_string_format(arena, "database handle is nil"));
+        return r;
+    }
+    sqlite3_stmt *stmt = NULL;
+    int rc = sqlite3_prepare_v2((sqlite3 *)db->handle, sql.data, sql.len, &stmt, NULL);
+    if (rc != SQLITE_OK || !stmt) {
+        r.v0 = gray_array_new(arena, sizeof(GrayMap), 0);
+        const char *errmsg = sqlite3_errmsg((sqlite3 *)db->handle);
+        r.v1 = gray_error_new(arena, gray_string_format(arena, "query_params failed: %s", errmsg ? errmsg : "unknown error"));
+        return r;
+    }
+    sqlite3_finalize(stmt);
+    r.v0 = gray_sqlite_query_params(arena, db, sql, params);
     r.v1 = NULL;
     return r;
 }

--- a/grayc/src/stdlib/sqlite.h
+++ b/grayc/src/stdlib/sqlite.h
@@ -44,7 +44,7 @@
  *@module sqlite
  *@group Queries
  *@sig exec(db Database, sql string) -> (bool, Error)
- *@desc Executes a SQL statement that does not return rows (CREATE, INSERT, UPDATE, DELETE, etc.). Returns true on success. Always use destructuring — single-variable assignment is a compile error. SQL strings are passed as-is; parameterized queries with placeholders are not supported.
+ *@desc Executes a SQL statement that does not return rows (CREATE, INSERT, UPDATE, DELETE, etc.). Returns true on success. Always use destructuring — single-variable assignment is a compile error. SQL strings are passed as-is; use exec_params for parameterized queries.
  *@example
  *   import @sqlite
  *   mut db, _ = sqlite.open("myapp.db")
@@ -54,15 +54,44 @@
  *@end
  */
 
+/*@man exec_params
+ *@module sqlite
+ *@group Queries
+ *@sig exec_params(db Database, sql string, params [string]) -> (bool, Error)
+ *@desc Executes a parameterized SQL statement that does not return rows. Use ? placeholders in the SQL string and pass values in the params array. Prevents SQL injection by binding parameters safely. Always use destructuring — single-variable assignment is a compile error.
+ *@example
+ *   import @sqlite
+ *   mut db, _ = sqlite.open("myapp.db")
+ *   mut ok, err = sqlite.exec_params(db, "INSERT INTO users (name, age) VALUES (?, ?)", {"Alice", "30"})
+ *   if err != nil { println("exec failed: ${err}") }
+ *@end
+ */
+
 /*@man query
  *@module sqlite
  *@group Queries
  *@sig query(db Database, sql string) -> ([map[string:string]], Error)
- *@desc Executes a SQL SELECT statement and returns the result rows. Each row is a map of column name to string value. Always use destructuring — single-variable assignment is a compile error. SQL strings are passed as-is; parameterized queries with placeholders are not supported.
+ *@desc Executes a SQL SELECT statement and returns the result rows. Each row is a map of column name to string value. Always use destructuring — single-variable assignment is a compile error. SQL strings are passed as-is; use query_params for parameterized queries.
  *@example
  *   import @sqlite
  *   mut db, _ = sqlite.open("myapp.db")
  *   mut rows, err = sqlite.query(db, "SELECT * FROM users")
+ *   if err != nil { println("query failed: ${err}") }
+ *   for_each row in rows {
+ *       println(row)
+ *   }
+ *@end
+ */
+
+/*@man query_params
+ *@module sqlite
+ *@group Queries
+ *@sig query_params(db Database, sql string, params [string]) -> ([map[string:string]], Error)
+ *@desc Executes a parameterized SQL SELECT statement and returns the result rows. Use ? placeholders in the SQL string and pass values in the params array. Prevents SQL injection by binding parameters safely. Always use destructuring — single-variable assignment is a compile error.
+ *@example
+ *   import @sqlite
+ *   mut db, _ = sqlite.open("myapp.db")
+ *   mut rows, err = sqlite.query_params(db, "SELECT * FROM users WHERE name = ?", {"Alice"})
  *   if err != nil { println("query failed: ${err}") }
  *   for_each row in rows {
  *       println(row)
@@ -83,14 +112,22 @@ void gray_sqlite_close(GraySqlite *db);
 /* sqlite.exec(db, sql) — execute statement, return success */
 bool gray_sqlite_exec(GraySqlite *db, GrayString sql);
 
+/* sqlite.exec_params(db, sql, params) — execute parameterized statement */
+bool gray_sqlite_exec_params(GraySqlite *db, GrayString sql, GrayArray params);
+
 /* sqlite.query(db, sql) — execute query, return array of maps */
 GrayArray gray_sqlite_query(GrayArena *arena, GraySqlite *db, GrayString sql);
+
+/* sqlite.query_params(db, sql, params) — execute parameterized query */
+GrayArray gray_sqlite_query_params(GrayArena *arena, GraySqlite *db, GrayString sql, GrayArray params);
 
 /* _result variants */
 typedef struct { GraySqlite *v0; GrayError *v1; } GrayResult_sqlite;
 
 GrayResult_sqlite gray_sqlite_open_result(GrayArena *arena, GrayString path);
 GrayResult_bool gray_sqlite_exec_result(GrayArena *arena, GraySqlite *db, GrayString sql);
+GrayResult_bool gray_sqlite_exec_params_result(GrayArena *arena, GraySqlite *db, GrayString sql, GrayArray params);
 GrayResult_array gray_sqlite_query_result(GrayArena *arena, GraySqlite *db, GrayString sql);
+GrayResult_array gray_sqlite_query_params_result(GrayArena *arena, GraySqlite *db, GrayString sql, GrayArray params);
 
 #endif

--- a/grayc/src/stdlib/strconv.c
+++ b/grayc/src/stdlib/strconv.c
@@ -17,15 +17,22 @@
 
 #define STRCONV_BUF_SIZE 64
 
+/* Truncate a GrayString into a stack buffer and null-terminate it.
+   Returns the (possibly clamped) length. */
+static int strconv_prepare(GrayString s, char *buf, size_t buf_size) {
+    int len = s.len < (int32_t)buf_size - 1 ? s.len : (int32_t)buf_size - 1;
+    memcpy(buf, s.data, (size_t)len);
+    buf[len] = '\0';
+    return len;
+}
+
 /* --- Panicking conversions --- */
 
 int64_t gray_strconv_to_int(GrayString s, int base) {
     if (base < 2 || base > 36)
         gray_panic_code("P0054", "strconv.to_int: invalid base %d; must be between 2 and 36", base);
     char buf[STRCONV_BUF_SIZE];
-    int len = s.len < (int32_t)sizeof(buf) - 1 ? s.len : (int32_t)sizeof(buf) - 1;
-    memcpy(buf, s.data, (size_t)len);
-    buf[len] = '\0';
+    int len = strconv_prepare(s, buf, sizeof(buf));
     if (len > 0 && isspace((unsigned char)buf[0]))
         gray_panic_code("P0055", "strconv.to_int: cannot convert '%s' to int (base %d)", buf, base);
     char *end = NULL;
@@ -40,9 +47,7 @@ uint64_t gray_strconv_to_uint(GrayString s, int base) {
     if (base < 2 || base > 36)
         gray_panic_code("P0056", "strconv.to_uint: invalid base %d; must be between 2 and 36", base);
     char buf[STRCONV_BUF_SIZE];
-    int len = s.len < (int32_t)sizeof(buf) - 1 ? s.len : (int32_t)sizeof(buf) - 1;
-    memcpy(buf, s.data, (size_t)len);
-    buf[len] = '\0';
+    int len = strconv_prepare(s, buf, sizeof(buf));
     if (len > 0 && isspace((unsigned char)buf[0]))
         gray_panic_code("P0057", "strconv.to_uint: cannot convert '%s' to uint (base %d)", buf, base);
     /* Reject negative numbers */
@@ -61,9 +66,7 @@ uint64_t gray_strconv_to_uint(GrayString s, int base) {
 
 double gray_strconv_to_float(GrayString s) {
     char buf[STRCONV_BUF_SIZE];
-    int len = s.len < (int32_t)sizeof(buf) - 1 ? s.len : (int32_t)sizeof(buf) - 1;
-    memcpy(buf, s.data, (size_t)len);
-    buf[len] = '\0';
+    int len = strconv_prepare(s, buf, sizeof(buf));
     if (len > 0 && isspace((unsigned char)buf[0]))
         gray_panic_code("P0059", "strconv.to_float: cannot convert '%s' to float", buf);
     char *end = NULL;
@@ -78,9 +81,7 @@ bool gray_strconv_to_bool(GrayString s) {
     if (s.len == 4 && strncasecmp(s.data, "true", 4) == 0) return true;
     if (s.len == 5 && strncasecmp(s.data, "false", 5) == 0) return false;
     char buf[STRCONV_BUF_SIZE];
-    int len = s.len < (int32_t)sizeof(buf) - 1 ? s.len : (int32_t)sizeof(buf) - 1;
-    memcpy(buf, s.data, (size_t)len);
-    buf[len] = '\0';
+    strconv_prepare(s, buf, sizeof(buf));
     gray_panic_code("P0060", "strconv.to_bool: cannot convert '%s' to bool", buf);
 }
 
@@ -93,9 +94,7 @@ GrayResult_int gray_strconv_to_int_result(GrayString s, int base) {
         return (GrayResult_int){0, err};
     }
     char buf[STRCONV_BUF_SIZE];
-    int len = s.len < (int32_t)sizeof(buf) - 1 ? s.len : (int32_t)sizeof(buf) - 1;
-    memcpy(buf, s.data, (size_t)len);
-    buf[len] = '\0';
+    int len = strconv_prepare(s, buf, sizeof(buf));
     if (len > 0 && isspace((unsigned char)buf[0])) {
         GrayString msg = gray_string_lit("cannot convert string to int");
         GrayError *err = gray_error_new(gray_default_arena, msg);
@@ -119,9 +118,7 @@ GrayResult_uint gray_strconv_to_uint_result(GrayString s, int base) {
         return (GrayResult_uint){0, err};
     }
     char buf[STRCONV_BUF_SIZE];
-    int len = s.len < (int32_t)sizeof(buf) - 1 ? s.len : (int32_t)sizeof(buf) - 1;
-    memcpy(buf, s.data, (size_t)len);
-    buf[len] = '\0';
+    int len = strconv_prepare(s, buf, sizeof(buf));
     if (len > 0 && isspace((unsigned char)buf[0])) {
         GrayString msg = gray_string_lit("cannot convert string to uint");
         GrayError *err = gray_error_new(gray_default_arena, msg);
@@ -149,9 +146,7 @@ GrayResult_uint gray_strconv_to_uint_result(GrayString s, int base) {
 
 GrayResult_float gray_strconv_to_float_result(GrayString s) {
     char buf[STRCONV_BUF_SIZE];
-    int len = s.len < (int32_t)sizeof(buf) - 1 ? s.len : (int32_t)sizeof(buf) - 1;
-    memcpy(buf, s.data, (size_t)len);
-    buf[len] = '\0';
+    int len = strconv_prepare(s, buf, sizeof(buf));
     if (len > 0 && isspace((unsigned char)buf[0])) {
         GrayString msg = gray_string_lit("cannot convert string to float");
         GrayError *err = gray_error_new(gray_default_arena, msg);

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -5274,6 +5274,10 @@ static GrayType *resolve_infix_expr(TypeChecker *checker, AstNode *node) {
     reject_void_in_context(checker, node->data.infix.left, left, "binary operand");
     reject_void_in_context(checker, node->data.infix.right, right, "binary operand");
 
+    /* E3040: multi-return calls cannot appear as operands */
+    reject_multi_return_in_single_position(checker, node->data.infix.left);
+    reject_multi_return_in_single_position(checker, node->data.infix.right);
+
     /* String ordering operators not supported; use strings.compare() */
     if ((left->kind == TK_STRING || right->kind == TK_STRING) &&
         (op == TOK_LT || op == TOK_GT ||
@@ -6342,6 +6346,8 @@ static GrayType *resolve_expression(TypeChecker *checker, AstNode *node) {
             GrayType *pt = resolve_expression(checker, part);
             /* Only check non-literal parts (the ${expr} expressions) */
             if (part->kind == NODE_STRING_VALUE || !pt) continue;
+            /* E3040: multi-return calls cannot appear in interpolation */
+            reject_multi_return_in_single_position(checker, part);
             /* Interpolation expressions are re-lexed by a sub-lexer on
              * the extracted ${...} text, so part tokens have positions
              * relative to that sub-stream; not the original file.
@@ -9574,6 +9580,8 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
             diagnostic_error_message(checker->diag, "E3038", msg,
                 NODE_FILE(checker, c), c->token.line, c->token.column, 0);
         }
+        /* E3040: multi-return calls cannot be used as if condition */
+        reject_multi_return_in_single_position(checker, node->data.if_stmt.condition);
         if (cond_t && cond_t->kind != TK_UNKNOWN &&
             (cond_t->kind == TK_STRING || cond_t->kind == TK_ARRAY ||
              cond_t->kind == TK_MAP   || cond_t->kind == TK_STRUCT)) {
@@ -10358,6 +10366,8 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
             AstNode *subj = node->data.when_stmt.value;
             diagnostic_warning_code(checker->diag, "W2012", NODE_FILE(checker, subj), subj->token.line, subj->token.column, 0);
         }
+        /* E3040: multi-return calls cannot be used as when subject */
+        reject_multi_return_in_single_position(checker, node->data.when_stmt.value);
         /* E3121: struct, array, map, and pointer types are not valid when subjects.
          * Null out when_t so subsequent case type checks are skipped. */
         if (when_t && (when_t->kind == TK_STRUCT || when_t->kind == TK_ARRAY ||

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -1182,10 +1182,12 @@ static const StdlibFuncMeta stdlib_func_meta[] = {
     {"server", "text",       2, 2, false, FT_NONE, 1, {{1, ARG_STRING}}, "HttpResponse"},
     {"server", "use",        2, 2, false, FT_NONE, 0, {{0}},"void"},
     /* sqlite */
-    {"sqlite", "close", 1, 1,  false, FT_NONE,            0, {{0}},"void"},
-    {"sqlite", "exec",  2, 99, true,  FT_BOOL,            0, {{0}},"bool"},
-    {"sqlite", "open",  1, 1,  true,  FT_STRUCT_DATABASE,  1, {{0, ARG_STRING}}, "Database"},
-    {"sqlite", "query", 2, 99, true,  FT_ARRAY_MAP,       0, {{0}},"[map]"},
+    {"sqlite", "close",        1, 1,  false, FT_NONE,            0, {{0}},"void"},
+    {"sqlite", "exec",         2, 99, true,  FT_BOOL,            0, {{0}},"bool"},
+    {"sqlite", "exec_params",  3, 3,  true,  FT_BOOL,            1, {{2, ARG_ARRAY}}, "bool"},
+    {"sqlite", "open",         1, 1,  true,  FT_STRUCT_DATABASE,  1, {{0, ARG_STRING}}, "Database"},
+    {"sqlite", "query",        2, 99, true,  FT_ARRAY_MAP,       0, {{0}},"[map]"},
+    {"sqlite", "query_params", 3, 3,  true,  FT_ARRAY_MAP,       1, {{2, ARG_ARRAY}}, "[map]"},
     /* strconv */
     {"strconv", "from_bool",  1, 1, false, FT_NONE,  1, {{0, ARG_BOOL}}, "string"},
     {"strconv", "from_float", 1, 1, false, FT_NONE,  1, {{0, ARG_FLOAT}}, "string"},

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -10582,7 +10582,9 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
             for (int const_index = 0; const_index < node->data.when_stmt.case_count && !has_enum_case; const_index++) {
                 for (int cj = 0; cj < node->data.when_stmt.cases[const_index].value_count && !has_enum_case; cj++) {
                     AstNode *cv = node->data.when_stmt.cases[const_index].values[cj];
-                    if (cv->kind == NODE_MEMBER_EXPR &&
+                    if (cv->kind == NODE_IMPLICIT_ENUM || cv->kind == NODE_WHEN_PATTERN) {
+                        has_enum_case = true;
+                    } else if (cv->kind == NODE_MEMBER_EXPR &&
                         cv->data.member.object->kind == NODE_LABEL) {
                         const char *name = cv->data.member.object->data.label.value;
                         if (is_enum_name(checker, name)) {

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -6331,6 +6331,12 @@ static GrayType *resolve_expression(TypeChecker *checker, AstNode *node) {
                 diagnostic_error_message(checker->diag, "E3041",
                     "cannot interpolate void expression; the function does not return a value",
                     NODE_FILE(checker, node), line, col, 0);
+            } else if (pt->kind == TK_ENUM && pt->name && typechecker_enum_is_tagged(checker, pt->name)) {
+                char *msg = typechecker_format(checker,
+                    "cannot interpolate tagged enum '%s'; use when/is to destructure the payload first",
+                    enum_display_name(checker, pt->name));
+                diagnostic_error_message(checker->diag, "E3041", msg,
+                    NODE_FILE(checker, node), line, col, 0);
             } else if (pt->kind == TK_STRUCT ||
                        pt->kind == TK_POINTER ||
                        is_func_type) {
@@ -7482,6 +7488,19 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
             strncmp(node->data.var_decl.type_name, "map[", 4) == 0) {
             diagnostic_error_code_help(checker->diag, "E3059", NODE_FILE(checker, node), node->token.line, node->token.column, 0,
                 "change 'const' to 'mut'; use a struct for fixed key-value data");
+        }
+        /* E5041: tagged enums cannot be map value types */
+        if (node->data.var_decl.type_name &&
+            strncmp(node->data.var_decl.type_name, "map[", 4) == 0) {
+            GrayType *map_t = typechecker_type_from_name(checker, node->data.var_decl.type_name);
+            if (map_t && map_t->value_type) {
+                GrayType *vt = typechecker_type_from_name(checker, map_t->value_type);
+                if (vt && vt->kind == TK_ENUM && vt->name && typechecker_enum_is_tagged(checker, vt->name)) {
+                    diagnostic_error_code_formatted(checker->diag, "E5041",
+                        NODE_FILE(checker, node), node->token.line, node->token.column, 0,
+                        enum_display_name(checker, vt->name));
+                }
+            }
         }
         /* const must have a value */
         if (!node->data.var_decl.mutable && !node->data.var_decl.value) {

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -4413,7 +4413,7 @@ static GrayType *resolve_direct_call(TypeChecker *checker, AstNode *node, const 
                 if (ar >= 5 && pr > 0 && pr < ar) {
                     char *msg = NULL;
                     msg = typechecker_format(checker,
-                        "argument %d of '%s': cannot implicitly narrow %s to %s; use %s() to convert explicitly",
+                        "argument %d of '%s': cannot implicitly narrow %s to %s; use cast(value, %s) to convert explicitly",
                         argument_index + 1, function_name, arg_t->name, param_t->name, param_t->name);
                     diagnostic_error_message(checker->diag, "E3001", msg,
                         NODE_FILE(checker, node->data.call.args[argument_index]), node->data.call.args[argument_index]->token.line,
@@ -7858,7 +7858,7 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
                 if (dr > 0 && vr >= 5 && dr < vr) {
                     char *msg = NULL;
                     msg = typechecker_format(checker,
-                        "type mismatch: cannot implicitly narrow %s to %s; use %s() to convert explicitly",
+                        "type mismatch: cannot implicitly narrow %s to %s; use cast(value, %s) to convert explicitly",
                         value_type->name, declared->name, declared->name);
                     diagnostic_error_message(checker->diag, "E3001", msg,
                         NODE_FILE(checker, node), node->token.line, node->token.column, 0);
@@ -9029,7 +9029,7 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
             if (dr > 0 && vr > 0 && dr < vr) {
                 char *msg = NULL;
                 msg = typechecker_format(checker,
-                    "type mismatch: cannot implicitly narrow %s to %s variable '%s'; use %s() to convert explicitly",
+                    "type mismatch: cannot implicitly narrow %s to %s variable '%s'; use cast(value, %s) to convert explicitly",
                     value_t->name, target_t->name, target->data.label.value, target_t->name);
                 diagnostic_error_message(checker->diag, "E3001", msg,
                     NODE_FILE(checker, node), node->token.line, node->token.column, 0);
@@ -9073,7 +9073,7 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
             strcmp(target_t->name, "f32") == 0) {
             char *msg = NULL;
             msg = typechecker_format(checker,
-                "type mismatch: cannot implicitly narrow %s to %s variable '%s'; use %s() to convert explicitly",
+                "type mismatch: cannot implicitly narrow %s to %s variable '%s'; use cast(value, %s) to convert explicitly",
                 value_t->name, target_t->name, target->data.label.value, target_t->name);
             diagnostic_error_message(checker->diag, "E3001", msg,
                 NODE_FILE(checker, node), node->token.line, node->token.column, 0);

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -1815,28 +1815,6 @@ static int int_type_name_rank(const char *n) {
     return 0;
 }
 
-static bool is_unsigned_type(const char *tn) {
-    if (!tn) return false;
-    return strcmp(tn, "uint") == 0 || strcmp(tn, "u8") == 0 ||
-           strcmp(tn, "u16") == 0 || strcmp(tn, "u32") == 0 ||
-           strcmp(tn, "u64") == 0 || strcmp(tn, "u128") == 0 ||
-           strcmp(tn, "u256") == 0 || strcmp(tn, "byte") == 0;
-}
-
-static bool is_signed_int_type(const char *tn) {
-    if (!tn) return false;
-    return strcmp(tn, "int") == 0 || strcmp(tn, "i8") == 0 ||
-           strcmp(tn, "i16") == 0 || strcmp(tn, "i32") == 0 ||
-           strcmp(tn, "i64") == 0 || strcmp(tn, "i128") == 0 ||
-           strcmp(tn, "i256") == 0;
-}
-
-static bool is_bigint_type(const char *tn) {
-    if (!tn) return false;
-    return strcmp(tn, "i128") == 0 || strcmp(tn, "u128") == 0 ||
-           strcmp(tn, "i256") == 0 || strcmp(tn, "u256") == 0;
-}
-
 /* --- Literal value extraction --- */
 
 /* Try to extract a compile-time integer value from a literal expression.
@@ -4017,11 +3995,9 @@ static GrayType *resolve_builtin_call(TypeChecker *checker, AstNode *node, const
         }
         result = &TYPE_CHAR;
     } else if ((strcmp(function_name, "int") == 0 ||
-                strcmp(function_name, "i128") == 0 ||
-                strcmp(function_name, "i256") == 0 ||
-                strcmp(function_name, "u128") == 0 ||
-                strcmp(function_name, "u256") == 0 || strcmp(function_name, "uint") == 0 ||
-                strcmp(function_name, "byte") == 0) &&
+                strcmp(function_name, "uint") == 0 ||
+                strcmp(function_name, "byte") == 0 ||
+                is_bigint_type(function_name)) &&
                node->data.call.arg_count == 1) {
         /* E3043: validate source type is convertible to numeric */
         GrayType *src_t = resolve_expression(checker, node->data.call.args[0]);
@@ -7386,13 +7362,7 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
              * detection is left to a separate check; for now we just ensure
              * the codegen fix applies (in_const_decl suppresses the runtime
              * wrapper). */
-            bool is_int_type =
-                strcmp(tn, "int") == 0 || strcmp(tn, "i64") == 0 ||
-                strcmp(tn, "i8") == 0 || strcmp(tn, "i16") == 0 || strcmp(tn, "i32") == 0 ||
-                strcmp(tn, "i128") == 0 || strcmp(tn, "i256") == 0 ||
-                strcmp(tn, "uint") == 0 || strcmp(tn, "u64") == 0 ||
-                strcmp(tn, "u8") == 0 || strcmp(tn, "u16") == 0 || strcmp(tn, "u32") == 0 ||
-                strcmp(tn, "u128") == 0 || strcmp(tn, "u256") == 0;
+            bool is_int_type = is_any_int_type(tn);
             if (is_int_type) {
                 int64_t folded = 0;
                 bool overflowed = false;

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -235,10 +235,7 @@ static bool path_contains_map_index(TypeChecker *checker, AstNode *e) {
 static void register_struct(TypeChecker *checker, const char *name,
     const char *display_name,
     const char **field_names, GrayType **field_types, int field_count) {
-    if (checker->struct_count >= checker->struct_cap) {
-        checker->struct_cap = checker->struct_cap ? checker->struct_cap * 2 : 8;
-        checker->structs = xrealloc(checker->structs, sizeof(StructInfo) * checker->struct_cap);
-    }
+    GROW_ARRAY(checker->structs, checker->struct_count, checker->struct_cap);
     checker->structs_sorted_built = false;
     StructInfo *si = &checker->structs[checker->struct_count++];
     si->struct_name = name;
@@ -558,10 +555,7 @@ static bool type_name_has_wildcard(const char *tn) {
 static void register_func(TypeChecker *checker, const char *name,
     GrayType **param_types, int param_count,
     GrayType **return_types, int return_count) {
-    if (checker->func_count >= checker->func_cap) {
-        checker->func_cap = checker->func_cap ? checker->func_cap * 2 : 16;
-        checker->funcs = xrealloc(checker->funcs, sizeof(FuncSig) * checker->func_cap);
-    }
+    GROW_ARRAY(checker->funcs, checker->func_count, checker->func_cap);
     checker->funcs_sorted_built = false;
     FuncSig *fs = &checker->funcs[checker->func_count++];
     fs->name = name;
@@ -9518,11 +9512,8 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
                         NODE_FILE(checker, node), node->token.line, node->token.column, 0,
                         "mem.destroy", arena_name, arena_name);
                 } else {
-                    if (checker->destroyed_arena_count >= checker->destroyed_arena_cap) {
-                        checker->destroyed_arena_cap = checker->destroyed_arena_cap ? checker->destroyed_arena_cap * 2 : 8;
-                        checker->destroyed_arenas = xrealloc(checker->destroyed_arenas,
-                            (size_t)checker->destroyed_arena_cap * sizeof(const char *));
-                    }
+                    GROW_ARRAY(checker->destroyed_arenas, checker->destroyed_arena_count,
+                        checker->destroyed_arena_cap);
                     checker->destroyed_arenas[checker->destroyed_arena_count++] = arena_name;
                 }
             }
@@ -9552,11 +9543,8 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
                         NODE_FILE(checker, node), node->token.line, node->token.column, 0,
                         "destroy", arena_name, arena_name);
                 } else {
-                    if (checker->destroyed_arena_count >= checker->destroyed_arena_cap) {
-                        checker->destroyed_arena_cap = checker->destroyed_arena_cap ? checker->destroyed_arena_cap * 2 : 8;
-                        checker->destroyed_arenas = xrealloc(checker->destroyed_arenas,
-                            (size_t)checker->destroyed_arena_cap * sizeof(const char *));
-                    }
+                    GROW_ARRAY(checker->destroyed_arenas, checker->destroyed_arena_count,
+                        checker->destroyed_arena_cap);
                     checker->destroyed_arenas[checker->destroyed_arena_count++] = arena_name;
                 }
             }

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -3242,8 +3242,18 @@ static GrayType *resolve_struct_or_module_call(TypeChecker *checker, AstNode *no
                     }
                     /* Rewrite the call AST: change the member-expr
                      * object from the instance label to the type
-                     * name, and prepend the instance as arg[0]. */
-                    fn->data.member.object->data.label.value = strdup(struct_name);
+                     * name, and prepend the instance as arg[0].
+                     * When the object is an explicit deref (p^.func),
+                     * replace it with a plain label node first. */
+                    if (fn->data.member.object->kind != NODE_LABEL) {
+                        AstNode *new_obj = xcalloc(1, sizeof(AstNode));
+                        new_obj->kind = NODE_LABEL;
+                        new_obj->token = fn->data.member.object->token;
+                        new_obj->data.label.value = strdup(struct_name);
+                        fn->data.member.object = new_obj;
+                    } else {
+                        fn->data.member.object->data.label.value = strdup(struct_name);
+                    }
                     int orig_count = node->data.call.arg_count;
                     AstNode **new_args = xmalloc(sizeof(AstNode *) * (orig_count + 1));
                     AstNode *self_arg = xcalloc(1, sizeof(AstNode));
@@ -3446,7 +3456,15 @@ static GrayType *resolve_struct_or_module_call(TypeChecker *checker, AstNode *no
                         snprintf(display, sizeof(display), "%s.%s", display_sname, mfn);
                         typechecker_resolve_named_arguments(checker, node, ssig->decl, display);
                     }
-                    fn->data.member.object->data.label.value = strdup(struct_name);
+                    if (fn->data.member.object->kind != NODE_LABEL) {
+                        AstNode *new_obj = xcalloc(1, sizeof(AstNode));
+                        new_obj->kind = NODE_LABEL;
+                        new_obj->token = fn->data.member.object->token;
+                        new_obj->data.label.value = strdup(struct_name);
+                        fn->data.member.object = new_obj;
+                    } else {
+                        fn->data.member.object->data.label.value = strdup(struct_name);
+                    }
                     ssig->used = true;
                     sym->used = true;
                     result = ssig->return_count > 0 ? ssig->return_types[0] : &TYPE_VOID;
@@ -5085,8 +5103,14 @@ static GrayType *resolve_call_expr(TypeChecker *checker, AstNode *node) {
         } else {
             result = &TYPE_UNKNOWN;
         }
-    } else if (fn->kind == NODE_MEMBER_EXPR && fn->data.member.object->kind == NODE_LABEL) {
-        const char *mod_raw = fn->data.member.object->data.label.value;
+    } else if (fn->kind == NODE_MEMBER_EXPR &&
+               (fn->data.member.object->kind == NODE_LABEL ||
+                (fn->data.member.object->kind == NODE_POSTFIX_EXPR &&
+                 fn->data.member.object->data.postfix.op == TOK_CARET &&
+                 fn->data.member.object->data.postfix.left->kind == NODE_LABEL))) {
+        const char *mod_raw = fn->data.member.object->kind == NODE_LABEL
+            ? fn->data.member.object->data.label.value
+            : fn->data.member.object->data.postfix.left->data.label.value;
         const char *mod = typechecker_resolve_alias(checker, mod_raw);
         const char *mfn = fn->data.member.member;
         /* Check that module is actually imported */

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -6603,7 +6603,15 @@ static GrayType *resolve_expression(TypeChecker *checker, AstNode *node) {
 
     case NODE_INDEX_EXPR: {
         GrayType *left = resolve_expression(checker, node->data.index_expr.left);
+        /* Propagate map key type as expected_type so .VARIANT resolves */
+        GrayType *saved_idx_expected = checker->expected_type;
+        if (left->kind == TK_MAP && left->key_type) {
+            GrayType *key_t = typechecker_type_from_name(checker, left->key_type);
+            if (key_t && key_t->kind == TK_ENUM && key_t->name)
+                checker->expected_type = key_t;
+        }
         GrayType *idx_t = resolve_expression(checker, node->data.index_expr.index);
+        checker->expected_type = saved_idx_expected;
         /* E3003: array index must be integer */
         if (left->kind == TK_ARRAY && idx_t->kind != TK_UNKNOWN &&
             !is_int_kind(idx_t->kind) && idx_t->kind != TK_BYTE) {

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -6723,6 +6723,14 @@ static GrayType *resolve_expression(TypeChecker *checker, AstNode *node) {
     }
 
     case NODE_MAP_VALUE: {
+        /* If expected_type is a map-of-enum, propagate value type for .VARIANT */
+        GrayType *saved_map_expected = checker->expected_type;
+        if (checker->expected_type && checker->expected_type->kind == TK_MAP &&
+            checker->expected_type->value_type) {
+            GrayType *val_t = typechecker_type_from_name(checker, checker->expected_type->value_type);
+            if (val_t && val_t->kind == TK_ENUM && val_t->name)
+                checker->expected_type = val_t;
+        }
         /* Resolve key and value types */
         for (int i = 0; i < node->data.map_value.count; i++) {
             GrayType *kt = resolve_expression(checker, node->data.map_value.keys[i]);
@@ -6761,6 +6769,7 @@ static GrayType *resolve_expression(TypeChecker *checker, AstNode *node) {
             t->value_type = strdup(vt ? type_name(vt) : "unknown");
         }
         result = t;
+        checker->expected_type = saved_map_expected;
         break;
     }
 
@@ -7651,6 +7660,10 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
             else if (declared->kind == TK_ARRAY && declared->element_type) {
                 GrayType *elem_t = typechecker_type_from_name(checker, declared->element_type);
                 if (elem_t && elem_t->kind == TK_ENUM)
+                    checker->expected_type = declared;
+            } else if (declared->kind == TK_MAP && declared->value_type) {
+                GrayType *val_t = typechecker_type_from_name(checker, declared->value_type);
+                if (val_t && val_t->kind == TK_ENUM)
                     checker->expected_type = declared;
             }
             GrayType *value_type = resolve_expression(checker, node->data.var_decl.value);

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -11131,6 +11131,14 @@ static void register_declarations(TypeChecker *checker, AstNode *program) {
                         break;
                     }
                 }
+                /* Resolve implicit enum selectors in field default values */
+                if (stmt->data.struct_decl.fields[j].default_value) {
+                    GrayType *saved_expected = checker->expected_type;
+                    if (ftypes[j] && ftypes[j]->kind == TK_ENUM && ftypes[j]->name)
+                        checker->expected_type = ftypes[j];
+                    resolve_expression(checker, stmt->data.struct_decl.fields[j].default_value);
+                    checker->expected_type = saved_expected;
+                }
             }
             /* E2037/E2038: reserved name check for structs */
             const char *sn = STRUCT_DISPLAY_NAME(stmt);

--- a/grayc/src/typechecker/types.h
+++ b/grayc/src/typechecker/types.h
@@ -12,6 +12,7 @@
 #define GRAYC_TYPES_H
 
 #include <stdbool.h>
+#include <string.h>
 
 typedef enum {
     TK_VOID,
@@ -86,5 +87,33 @@ GrayType *type_from_name(const char *name);
 
 /* Free all heap strings owned by pool entries and reset the pool */
 void type_pool_reset(void);
+
+/* --- Type-name string predicates --- */
+
+static inline bool is_unsigned_type(const char *tn) {
+    if (!tn) return false;
+    return strcmp(tn, "uint") == 0 || strcmp(tn, "u8") == 0 ||
+           strcmp(tn, "u16") == 0 || strcmp(tn, "u32") == 0 ||
+           strcmp(tn, "u64") == 0 || strcmp(tn, "u128") == 0 ||
+           strcmp(tn, "u256") == 0 || strcmp(tn, "byte") == 0;
+}
+
+static inline bool is_signed_int_type(const char *tn) {
+    if (!tn) return false;
+    return strcmp(tn, "int") == 0 || strcmp(tn, "i8") == 0 ||
+           strcmp(tn, "i16") == 0 || strcmp(tn, "i32") == 0 ||
+           strcmp(tn, "i64") == 0 || strcmp(tn, "i128") == 0 ||
+           strcmp(tn, "i256") == 0;
+}
+
+static inline bool is_any_int_type(const char *tn) {
+    return is_signed_int_type(tn) || is_unsigned_type(tn);
+}
+
+static inline bool is_bigint_type(const char *tn) {
+    if (!tn) return false;
+    return strcmp(tn, "i128") == 0 || strcmp(tn, "u128") == 0 ||
+           strcmp(tn, "i256") == 0 || strcmp(tn, "u256") == 0;
+}
 
 #endif

--- a/grayc/src/util/colors.h
+++ b/grayc/src/util/colors.h
@@ -1,0 +1,19 @@
+/*
+ * colors.h — Shared ANSI color escape macros used by both the compiler
+ * diagnostic system (error.c) and the runtime panic output (runtime.c).
+ *
+ * Copyright (c) 2025-Present Marshall A Burns
+ * Licensed under the MIT License. See LICENSE for details.
+ */
+
+#ifndef GRAY_COLORS_H
+#define GRAY_COLORS_H
+
+#define COL_RESET   "\033[0m"
+#define COL_BOLD    "\033[1m"
+#define COL_RED     "\033[31m"
+#define COL_YELLOW  "\033[33m"
+#define COL_BLUE    "\033[34m"
+#define COL_CYAN    "\033[36m"
+
+#endif

--- a/grayc/src/util/error.c
+++ b/grayc/src/util/error.c
@@ -21,14 +21,7 @@
 #define DIAG_INITIAL_CAP     16
 #define DIAG_FORMAT_BUF      1024
 
-/* --- ANSI color codes --- */
-
-#define COL_RESET   "\033[0m"
-#define COL_BOLD    "\033[1m"
-#define COL_RED     "\033[31m"
-#define COL_YELLOW  "\033[33m"
-#define COL_CYAN    "\033[36m"
-#define COL_BLUE    "\033[34m"
+#include "colors.h"
 
 static const char *col(DiagnosticList *diagnostics, const char *code) {
     return diagnostics->use_color ? code : "";

--- a/grayc/src/util/error_codes.h
+++ b/grayc/src/util/error_codes.h
@@ -270,7 +270,8 @@
     GRAY_ERROR("E5037", "usage", "copy() cannot be applied to a pointer; dereference first with copy(p^)") \
     GRAY_ERROR("E5038", "usage", "tagged enum '%s' cannot be passed to %s(); use when/is to destructure the payload first") \
     GRAY_ERROR("E5039", "usage", "constant expression overflows type '%s'") \
-    GRAY_ERROR("E5040", "usage", "constant requires a compile-time value; function calls are evaluated at runtime")
+    GRAY_ERROR("E5040", "usage", "constant requires a compile-time value; function calls are evaluated at runtime") \
+    GRAY_ERROR("E5041", "usage", "tagged enum '%s' cannot be used as a map value type; use when/is to destructure before storing")
 
 /* --- E6xxx: Import Problems --- */
 #define GRAY_IMPORT_ERRORS \

--- a/grayc/src/util/xalloc.h
+++ b/grayc/src/util/xalloc.h
@@ -60,4 +60,18 @@ static inline char *read_file_to_string(const char *path) {
     return buf;
 }
 
+/* Initial capacity for GROW_ARRAY — small enough to avoid waste,
+ * large enough to cover the common case without early resizes. */
+#define GROW_ARRAY_INIT_CAP 8
+
+/* Grow a dynamic array when count reaches capacity.
+ * Doubles capacity (starting from GROW_ARRAY_INIT_CAP), then xrealloc's. */
+#define GROW_ARRAY(arr, count, cap) \
+    do { \
+        if ((count) >= (cap)) { \
+            (cap) = (cap) ? (cap) * 2 : GROW_ARRAY_INIT_CAP; \
+            (arr) = xrealloc((arr), sizeof(*(arr)) * (size_t)(cap)); \
+        } \
+    } while (0)
+
 #endif

--- a/grayc/tests/test_util.c
+++ b/grayc/tests/test_util.c
@@ -270,10 +270,15 @@ int main(void) {
 
     printf("--- Buffer ---\n");
     RUN_TEST(test_buffer_create);
+    RUN_TEST(test_append_string_to_buffer);
+    RUN_TEST(test_append_bytes_to_buffer);
     RUN_TEST(test_buffer_append_growth);
+    RUN_TEST(test_append_format_to_buffer);
     RUN_TEST(test_buffer_append_formatted_large);
+    RUN_TEST(test_append_char_to_buffer);
     RUN_TEST(test_buffer_append_char_boundary);
     RUN_TEST(test_buffer_append_indent_zero);
+    RUN_TEST(test_append_indent_to_buffer);
     RUN_TEST(test_buffer_append_indent_large);
 
     printf("--- Scope ---\n");

--- a/integration-tests/fail/errors/E3001_narrowing_hint_cast_syntax.gray
+++ b/integration-tests/fail/errors/E3001_narrowing_hint_cast_syntax.gray
@@ -1,0 +1,5 @@
+// Verify that narrowing error hints suggest cast(value, type) syntax
+do main() {
+    mut c u8 = cast(10, u8)
+    c += 2
+}

--- a/integration-tests/fail/errors/E3040_multi_return_in_arithmetic.gray
+++ b/integration-tests/fail/errors/E3040_multi_return_in_arithmetic.gray
@@ -1,0 +1,6 @@
+// Multi-return function cannot appear as arithmetic operand
+do two() -> (int, int) { return 5, 10 }
+do main() {
+    mut x int = two() + 5
+    println("${x}")
+}

--- a/integration-tests/fail/errors/E3040_multi_return_in_comparison.gray
+++ b/integration-tests/fail/errors/E3040_multi_return_in_comparison.gray
@@ -1,0 +1,5 @@
+// Multi-return function cannot appear in comparison expression
+do two() -> (int, int) { return 5, 10 }
+do main() {
+    if two() == 5 { println("equal") }
+}

--- a/integration-tests/fail/errors/E3040_multi_return_in_if_condition.gray
+++ b/integration-tests/fail/errors/E3040_multi_return_in_if_condition.gray
@@ -1,0 +1,5 @@
+// Multi-return function cannot appear as if condition
+do two() -> (int, bool) { return 10, true }
+do main() {
+    if two() { println("true") }
+}

--- a/integration-tests/fail/errors/E3040_multi_return_in_interpolation.gray
+++ b/integration-tests/fail/errors/E3040_multi_return_in_interpolation.gray
@@ -1,0 +1,5 @@
+// Multi-return function cannot appear in string interpolation
+do two() -> (int, int) { return 5, 10 }
+do main() {
+    println("value: ${two()}")
+}

--- a/integration-tests/fail/errors/E3040_multi_return_in_when_subject.gray
+++ b/integration-tests/fail/errors/E3040_multi_return_in_when_subject.gray
@@ -1,0 +1,8 @@
+// Multi-return function cannot appear as when subject
+do two() -> (int, int) { return 5, 10 }
+do main() {
+    when two() {
+        is 5 { println("five") }
+        default { println("other") }
+    }
+}

--- a/integration-tests/fail/errors/E3041_tagged_enum_in_interpolation.gray
+++ b/integration-tests/fail/errors/E3041_tagged_enum_in_interpolation.gray
@@ -1,0 +1,18 @@
+/*
+ * Error Test: E3041 - tagged enum in string interpolation
+ *
+ * "${r}" where r is a tagged enum used to fall through codegen's
+ * default %lld + (long long) cast and produce a raw clang diagnostic.
+ * Typechecker now rejects at the interpolation site.
+ */
+
+const Result enum {
+    Ok(int)
+    Err(string)
+    None
+}
+
+do main() {
+    mut r Result = .Ok(42)
+    println("result: ${r}")
+}

--- a/integration-tests/fail/errors/E5041_tagged_enum_map_value.gray
+++ b/integration-tests/fail/errors/E5041_tagged_enum_map_value.gray
@@ -1,0 +1,17 @@
+/*
+ * Error Test: E5041 - tagged enum as map value type
+ *
+ * map[string:Status] where Status is a tagged enum. Codegen emits
+ * int64_t for map value storage but tagged enums are C structs,
+ * causing a type mismatch. Typechecker now rejects the declaration.
+ */
+
+const Status enum {
+    Active(int)
+    Inactive
+}
+
+do main() {
+    mut m map[string:Status] = {:}
+    m["a"] = Status.Active(1)
+}

--- a/integration-tests/pass/core/arrays_append_char_byte.gray
+++ b/integration-tests/pass/core/arrays_append_char_byte.gray
@@ -1,0 +1,39 @@
+import @arrays
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    // char append
+    mut chars [char] = {}
+    arrays.append(chars, 'A')
+    arrays.append(chars, 'Z')
+    if chars[0] == 'A' {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+    if chars[1] == 'Z' {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+
+    // byte append
+    mut barr [byte] = {}
+    arrays.append(barr, cast(0xFF, byte))
+    arrays.append(barr, cast(0x00, byte))
+    if barr[0] == cast(255, byte) {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+    if barr[1] == cast(0, byte) {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+
+    println("passed: ${passed}")
+    println("failed: ${failed}")
+}

--- a/integration-tests/pass/core/arrays_append_enum.gray
+++ b/integration-tests/pass/core/arrays_append_enum.gray
@@ -1,0 +1,64 @@
+import @arrays
+
+const Color enum {
+    RED
+    GREEN
+    BLUE
+}
+
+const Shape enum {
+    Circle(float)
+    Rect(float, float)
+    Point
+}
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    // Test 1: append non-tagged enum
+    mut colors [Color] = {}
+    arrays.append(colors, Color.RED)
+    arrays.append(colors, Color.GREEN)
+    if len(colors) == 2 && colors[0] == Color.RED && colors[1] == Color.GREEN {
+        println("  [PASS] append non-tagged enum")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] append non-tagged enum")
+        failed += 1
+    }
+
+    // Test 2: append tagged enum
+    mut shapes [Shape] = {}
+    arrays.append(shapes, Shape.Circle(3.14))
+    arrays.append(shapes, Shape.Point)
+    if len(shapes) == 2 {
+        println("  [PASS] append tagged enum")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] append tagged enum")
+        failed += 1
+    }
+
+    // Test 3: insert_at with enum
+    arrays.insert_at(colors, 1, Color.BLUE)
+    if len(colors) == 3 && colors[1] == Color.BLUE {
+        println("  [PASS] insert_at enum")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] insert_at enum")
+        failed += 1
+    }
+
+    // Test 4: prepend with enum
+    arrays.prepend(colors, Color.BLUE)
+    if len(colors) == 4 && colors[0] == Color.BLUE {
+        println("  [PASS] prepend enum")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] prepend enum")
+        failed += 1
+    }
+
+    println("Results: ${passed} passed, ${failed} failed")
+}

--- a/integration-tests/pass/core/arrays_append_wide_int.gray
+++ b/integration-tests/pass/core/arrays_append_wide_int.gray
@@ -1,0 +1,45 @@
+import @arrays
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    // i128
+    mut i128s [i128] = {}
+    arrays.append(i128s, cast(42, i128))
+    if len(i128s) == 1 {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+
+    // u128
+    mut u128s [u128] = {}
+    arrays.append(u128s, cast(99, u128))
+    if len(u128s) == 1 {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+
+    // i256
+    mut i256s [i256] = {}
+    arrays.append(i256s, cast(7, i256))
+    if len(i256s) == 1 {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+
+    // u256
+    mut u256s [u256] = {}
+    arrays.append(u256s, cast(88, u256))
+    if len(u256s) == 1 {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+
+    println("passed: ${passed}")
+    println("failed: ${failed}")
+}

--- a/integration-tests/pass/core/arrays_fill_char_byte_wide.gray
+++ b/integration-tests/pass/core/arrays_fill_char_byte_wide.gray
@@ -1,0 +1,45 @@
+import @arrays
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    // char fill
+    mut chars [char] = {}
+    arrays.fill(chars, 'X', 3)
+    if len(chars) == 3 {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+
+    // byte fill
+    mut barr [byte] = {}
+    arrays.fill(barr, cast(0xAB, byte), 2)
+    if len(barr) == 2 {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+
+    // i128 fill
+    mut i128s [i128] = {}
+    arrays.fill(i128s, cast(42, i128), 3)
+    if len(i128s) == 3 {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+
+    // u256 fill
+    mut u256s [u256] = {}
+    arrays.fill(u256s, cast(7, u256), 2)
+    if len(u256s) == 2 {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+
+    println("passed: ${passed}")
+    println("failed: ${failed}")
+}

--- a/integration-tests/pass/core/enum_array_interpolation.gray
+++ b/integration-tests/pass/core/enum_array_interpolation.gray
@@ -1,0 +1,43 @@
+const Color enum {
+    RED
+    GREEN
+    BLUE
+}
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    // Test 1: enum array interpolation
+    mut colors [Color] = {Color.RED, Color.GREEN, Color.BLUE}
+    mut result string = "${colors}"
+    if result == "{0, 1, 2}" {
+        println("  [PASS] enum array interpolation")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] enum array interpolation: got ${result}")
+        failed += 1
+    }
+
+    // Test 2: single-element enum array
+    mut one [Color] = {Color.GREEN}
+    mut result2 string = "${one}"
+    if result2 == "{1}" {
+        println("  [PASS] single-element enum array interpolation")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] single-element enum array interpolation: got ${result2}")
+        failed += 1
+    }
+
+    // Test 3: individual element access still works
+    if colors[0] == Color.RED && colors[1] == Color.GREEN && colors[2] == Color.BLUE {
+        println("  [PASS] individual enum element access")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] individual enum element access")
+        failed += 1
+    }
+
+    println("Results: ${passed} passed, ${failed} failed")
+}

--- a/integration-tests/pass/core/explicit_deref_struct_func.gray
+++ b/integration-tests/pass/core/explicit_deref_struct_func.gray
@@ -1,0 +1,52 @@
+const Vec2 struct {
+    x int
+    y int
+    do sum(v Vec2) -> int {
+        return v.x + v.y
+    }
+    do scale(&self Vec2, factor int) {
+        self.x = self.x * factor
+        self.y = self.y * factor
+    }
+}
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    mut p = new(Vec2)
+    p^.x = 3
+    p^.y = 4
+
+    // explicit deref with value self
+    mut s = p^.sum()
+    if s == 7 {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+
+    // explicit deref with mutable self
+    p^.scale(2)
+    if p^.x == 6 {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+    if p^.y == 8 {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+
+    // auto-deref still works
+    mut s2 = p.sum()
+    if s2 == 14 {
+        passed = passed + 1
+    } otherwise {
+        failed = failed + 1
+    }
+
+    println("passed: ${passed}")
+    println("failed: ${failed}")
+}

--- a/integration-tests/pass/core/implicit_enum_map_value.gray
+++ b/integration-tests/pass/core/implicit_enum_map_value.gray
@@ -1,0 +1,25 @@
+// Implicit enum selectors resolve as map literal values
+const Color enum {
+    RED
+    GREEN
+    BLUE
+}
+
+do main() {
+    mut passed = 0
+    mut failed = 0
+
+    mut m map[string:Color] = {"stop": .RED, "go": .GREEN, "sky": .BLUE}
+    if m["stop"] == Color.RED {
+        passed++
+    } otherwise {
+        failed++
+    }
+    if m["sky"] == Color.BLUE {
+        passed++
+    } otherwise {
+        failed++
+    }
+
+    println("${passed} passed, ${failed} failed")
+}

--- a/integration-tests/pass/core/implicit_enum_selector.gray
+++ b/integration-tests/pass/core/implicit_enum_selector.gray
@@ -170,6 +170,27 @@ do main() {
         failed += 1
     }
 
+    // Test 12: Map key bracket access (assignment)
+    mut palette [Color:string] = {:}
+    palette[.RED] = "#FF0000"
+    if palette[Color.RED] == "#FF0000" {
+        println("  [PASS] map key bracket assignment")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] map key bracket assignment")
+        failed += 1
+    }
+
+    // Test 13: Map key bracket access (read)
+    mut label string = palette[.RED]
+    if label == "#FF0000" {
+        println("  [PASS] map key bracket read")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] map key bracket read")
+        failed += 1
+    }
+
     // Summary
     println("")
     println("Results: ${passed} passed, ${failed} failed")

--- a/integration-tests/pass/core/implicit_enum_struct_field_default.gray
+++ b/integration-tests/pass/core/implicit_enum_struct_field_default.gray
@@ -1,0 +1,79 @@
+/*
+ * Pass Test: Implicit enum selector in struct field default values
+ * Tests that .VARIANT syntax works in struct field defaults.
+ */
+
+const Status enum {
+    PENDING
+    ACTIVE
+    DONE
+}
+
+const Task struct {
+    status Status = .PENDING
+}
+
+const Job struct {
+    state Status = .ACTIVE
+    name string = "untitled"
+}
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    // Test 1: implicit enum default used via empty literal
+    mut t = Task{}
+    if t.status == Status.PENDING {
+        println("  [PASS] Task{}.status == PENDING")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] Task{}.status: expected PENDING")
+        failed += 1
+    }
+
+    // Test 2: implicit enum default used via new()
+    mut t2 = new(Task)
+    if t2^.status == Status.PENDING {
+        println("  [PASS] new(Task).status == PENDING")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] new(Task).status: expected PENDING")
+        failed += 1
+    }
+
+    // Test 3: override implicit enum default
+    mut t3 = Task{status: .DONE}
+    if t3.status == Status.DONE {
+        println("  [PASS] Task{status: .DONE}.status == DONE")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] Task{status: .DONE}: expected DONE")
+        failed += 1
+    }
+
+    // Test 4: second field with implicit enum default
+    mut j = Job{}
+    if j.state == Status.ACTIVE {
+        println("  [PASS] Job{}.state == ACTIVE")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] Job{}.state: expected ACTIVE")
+        failed += 1
+    }
+
+    if j.name == "untitled" {
+        println("  [PASS] Job{}.name == \"untitled\"")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] Job{}.name: expected \"untitled\"")
+        failed += 1
+    }
+
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/integration-tests/pass/core/or_return_custom_error_fallback.gray
+++ b/integration-tests/pass/core/or_return_custom_error_fallback.gray
@@ -1,0 +1,28 @@
+// or_return with user-provided error fallback value
+do read_file(path string) -> (string, Error) {
+    return "", error("file not found")
+}
+
+do load() -> (string, Error) {
+    mut content = read_file("data.txt") or_return "", error("failed to load")
+    return content, nil
+}
+
+do main() {
+    mut passed = 0
+    mut failed = 0
+
+    mut val, err = load()
+    if val == "" {
+        passed++
+    } otherwise {
+        failed++
+    }
+    if err != nil {
+        passed++
+    } otherwise {
+        failed++
+    }
+
+    println("${passed} passed, ${failed} failed")
+}

--- a/integration-tests/pass/core/tagged_enum_compound_payloads.gray
+++ b/integration-tests/pass/core/tagged_enum_compound_payloads.gray
@@ -1,0 +1,90 @@
+const Wrapper enum {
+    Val(int)
+    Ptr(^int)
+}
+
+const Container enum {
+    Empty
+    Items([int])
+}
+
+const MapHolder enum {
+    None
+    Data(map[string:int])
+}
+
+const Multi enum {
+    Pair(^int, [int])
+}
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    // pointer payload
+    mut x int = 42
+    mut w = Wrapper.Ptr(addr(x))
+    when w {
+        is Ptr(p) {
+            if p^ == 42 {
+                passed = passed + 1
+            } otherwise {
+                failed = failed + 1
+            }
+        }
+        default {
+            failed = failed + 1
+        }
+    }
+
+    // array payload
+    mut c = Container.Items({10, 20, 30})
+    when c {
+        is Items(arr) {
+            if arr[0] == 10 {
+                passed = passed + 1
+            } otherwise {
+                failed = failed + 1
+            }
+        }
+        default {
+            failed = failed + 1
+        }
+    }
+
+    // map payload
+    mut m map[string:int] = {:}
+    m["key"] = 99
+    mut mh = MapHolder.Data(m)
+    when mh {
+        is Data(d) {
+            if d["key"] == 99 {
+                passed = passed + 1
+            } otherwise {
+                failed = failed + 1
+            }
+        }
+        default {
+            failed = failed + 1
+        }
+    }
+
+    // multi-payload with compound types
+    mut y int = 7
+    mut mp = Multi.Pair(addr(y), {1, 2})
+    when mp {
+        is Pair(ptr, arr) {
+            if ptr^ == 7 {
+                passed = passed + 1
+            } otherwise {
+                failed = failed + 1
+            }
+        }
+        default {
+            failed = failed + 1
+        }
+    }
+
+    println("passed: ${passed}")
+    println("failed: ${failed}")
+}

--- a/integration-tests/pass/stdlib/csv_quoted_unescape.gray
+++ b/integration-tests/pass/stdlib/csv_quoted_unescape.gray
@@ -1,0 +1,64 @@
+/*
+ * csv_quoted_unescape.gray - Test RFC 4180 §2.7 doubled-quote unescaping
+ */
+
+import @csv
+
+do main() {
+    println("=== CSV Quoted Unescape Test ===")
+    mut passed int = 0
+    mut failed int = 0
+
+    // Test 1: doubled quotes in a quoted field are unescaped
+    mut data1 string = "col\n\"has \"\"quotes\"\" inside\""
+    mut rows1 [[string]] = csv.parse(data1)
+    if rows1[1][0] == "has \"quotes\" inside" {
+        println("  [PASS] doubled quotes unescaped")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] doubled quotes unescaped: got '${rows1[1][0]}'")
+        failed += 1
+    }
+
+    // Test 2: quoted field with no doubled quotes stays unchanged
+    mut data2 string = "\"simple value\",other"
+    mut rows2 [[string]] = csv.parse(data2)
+    if rows2[0][0] == "simple value" {
+        println("  [PASS] quoted field without doubled quotes")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] quoted field without doubled quotes: got '${rows2[0][0]}'")
+        failed += 1
+    }
+
+    // Test 3: field that is just a doubled quote
+    mut data3 string = "\"\"\"\""
+    mut rows3 [[string]] = csv.parse(data3)
+    if rows3[0][0] == "\"" {
+        println("  [PASS] single doubled quote unescaped")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] single doubled quote unescaped: got '${rows3[0][0]}'")
+        failed += 1
+    }
+
+    // Test 4: comma inside quoted field still works
+    mut data4 string = "\"value with, comma\""
+    mut rows4 [[string]] = csv.parse(data4)
+    if rows4[0][0] == "value with, comma" {
+        println("  [PASS] comma in quoted field preserved")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] comma in quoted field: got '${rows4[0][0]}'")
+        failed += 1
+    }
+
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+        exit(1)
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/integration-tests/pass/stdlib/sqlite_params.gray
+++ b/integration-tests/pass/stdlib/sqlite_params.gray
@@ -1,0 +1,98 @@
+/*
+ * sqlite_params.gray - Integration test for parameterized queries
+ */
+
+import @sqlite
+
+do main() {
+    println("=== SQLite Parameterized Query Test ===")
+    mut passed int = 0
+    mut failed int = 0
+
+    mut db, _ = sqlite.open(":memory:")
+    mut _, _ = sqlite.exec(db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age TEXT)")
+
+    // exec_params: insert with parameterized values
+    mut ok, err = sqlite.exec_params(db, "INSERT INTO users (id, name, age) VALUES (?, ?, ?)", {"1", "Alice", "30"})
+    if ok {
+        println("  [PASS] exec_params INSERT")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] exec_params INSERT: ${err}")
+        failed += 1
+    }
+
+    // exec_params: insert value containing SQL metacharacters
+    mut ok2, err2 = sqlite.exec_params(db, "INSERT INTO users (id, name, age) VALUES (?, ?, ?)", {"2", "O'Brien; DROP TABLE users; --", "25"})
+    if ok2 {
+        println("  [PASS] exec_params with SQL metacharacters")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] exec_params with SQL metacharacters: ${err2}")
+        failed += 1
+    }
+
+    // query_params: retrieve by name
+    mut rows, qerr = sqlite.query_params(db, "SELECT * FROM users WHERE name = ?", {"Alice"})
+    if qerr != nil {
+        println("  [FAIL] query_params: ${qerr}")
+        failed += 1
+    } otherwise {
+        if len(rows) == 1 {
+            println("  [PASS] query_params returns 1 row for Alice")
+            passed += 1
+        } otherwise {
+            println("  [FAIL] query_params: expected 1 row, got ${len(rows)}")
+            failed += 1
+        }
+    }
+
+    // query_params: SQL injection attempt returns no rows
+    mut rows2, qerr2 = sqlite.query_params(db, "SELECT * FROM users WHERE name = ?", {"' OR '1'='1"})
+    if qerr2 != nil {
+        println("  [FAIL] query_params injection test: ${qerr2}")
+        failed += 1
+    } otherwise {
+        if len(rows2) == 0 {
+            println("  [PASS] query_params safely handles injection attempt")
+            passed += 1
+        } otherwise {
+            println("  [FAIL] query_params injection: expected 0 rows, got ${len(rows2)}")
+            failed += 1
+        }
+    }
+
+    // query_params: integer parameter bound as text works via SQLite type affinity
+    mut rows3, qerr3 = sqlite.query_params(db, "SELECT * FROM users WHERE id = ?", {"1"})
+    if qerr3 != nil {
+        println("  [FAIL] query_params integer bind: ${qerr3}")
+        failed += 1
+    } otherwise {
+        if len(rows3) == 1 {
+            println("  [PASS] query_params integer parameter binding")
+            passed += 1
+        } otherwise {
+            println("  [FAIL] query_params integer bind: expected 1 row, got ${len(rows3)}")
+            failed += 1
+        }
+    }
+
+    // verify the metacharacter row survived (table not dropped)
+    mut rows4, _ = sqlite.query(db, "SELECT * FROM users")
+    if len(rows4) == 2 {
+        println("  [PASS] table intact after metacharacter insert")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] expected 2 total rows, got ${len(rows4)}")
+        failed += 1
+    }
+
+    sqlite.close(db)
+
+    println("")
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        panic("Some tests failed!")
+    }
+    println("ALL TESTS PASSED")
+}

--- a/integration-tests/pass/warnings/W3005_implicit_enum_selector.gray
+++ b/integration-tests/pass/warnings/W3005_implicit_enum_selector.gray
@@ -1,0 +1,21 @@
+/*
+ * Warning Test: W3005 - implicit enum selector in when/is
+ * Expected: warning about non-strict when without default
+ */
+
+const Direction enum {
+    NORTH
+    SOUTH
+    EAST
+    WEST
+}
+
+do main() {
+    mut d Direction = .NORTH
+
+    when d {
+        is .NORTH {
+            println("north")
+        }
+    }
+}

--- a/integration-tests/pass/warnings/W3005_tagged_enum_pattern.gray
+++ b/integration-tests/pass/warnings/W3005_tagged_enum_pattern.gray
@@ -1,0 +1,20 @@
+/*
+ * Warning Test: W3005 - tagged enum destructuring pattern in when/is
+ * Expected: warning about non-strict when without default
+ */
+
+const Shape enum {
+    Circle(float)
+    Rect(float, float)
+    Point
+}
+
+do main() {
+    mut s Shape = .Circle(3.14)
+
+    when s {
+        is .Circle(r) {
+            println("circle r=${r}")
+        }
+    }
+}


### PR DESCRIPTION
This PR contains several bugfixes as well as changes focusing on maintainability and readability through refactors, performance and optimization improvments.

## Summary

### Bugfixes
-  fix implicit enum selector resolution in map keys/values/struct defaults
-  fix multi-return rejection in 5 expression contexts
-  fix tagged enum interpolation/map-value rejection
-  fix correct narrowing hint to use `cast()` syntax
-  fix compound types in tagged enum payloads
-  fix element types for `arrays.fill`/`append`/`insert_at`/`prepend` with wide ints/char/byte/enums
-  fix explicit deref syntax that broke struct function calls
-  fix `or_return` fallback count
-  fix  quoted field unescaping  in`@csv` stdlib module 
-  fix parameterized queries in `@sqlite` stdlib module
-  added a CLI unknown command error message

### Maintainability and performance optimizations/refactors
-  consolidate panic functions and ANSI colors
-  extract `gray_cstr()` helper
-  add `GROW_ARRAY` macro
-  add integer type name predicates
-  add temp variable counters
-  UTF-8 encode/decode dedup
-  shared conversion validation
-  add `ARRAY_CHECK_ITER` guard macro
-  add print function macro generation
-  when-pattern speculative parse dedup, binary codec macro

