### PR TITLE
fix(typechecker): unify cross-module enum type identity

### DIFF
--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -5463,12 +5463,13 @@ static GrayType *resolve_infix_expr(TypeChecker *checker, AstNode *node) {
 
     /* E3032: different enum types in comparison — catches both
      * direct enum literals (Color.RED == Dir.NORTH) and variables
-     * of different enum types (c == d where c:Color, d:Dir). */
+     * of different enum types (c == d where c:Color, d:Dir).
+     * Use display-name comparison so cross-module aliases unify. */
     if (!infix_errored &&
         (op == TOK_EQ || op == TOK_NOT_EQ) &&
         left->kind == TK_ENUM && right->kind == TK_ENUM &&
         left->name && right->name &&
-        strcmp(left->name, right->name) != 0) {
+        !typechecker_same_enum_type(checker, left->name, right->name)) {
         diagnostic_error_code_formatted(checker->diag, "E3032", NODE_FILE(checker, node), node->token.line, node->token.column, 0,
             enum_display_name(checker, left->name), enum_display_name(checker, right->name));
         infix_errored = true;
@@ -5708,12 +5709,21 @@ static GrayType *resolve_member_expr(TypeChecker *checker, AstNode *node) {
         snprintf(prefixed_type, sizeof(prefixed_type), "%s_%s", mod_name, type_name);
         /* Check if it's a module-qualified enum access */
         if (is_enum_name(checker, prefixed_type)) {
-            bool is_str_enum = false;
+            /* Validate variant exists */
+            bool member_found = false;
             for (int enum_index = 0; enum_index < checker->enum_count; enum_index++) {
                 if (strcmp(checker->enum_names[enum_index], prefixed_type) == 0) {
-                    is_str_enum = checker->enum_is_string[enum_index];
+                    for (int variant_index = 0; variant_index < checker->enum_value_counts[enum_index]; variant_index++) {
+                        if (strcmp(checker->enum_values[enum_index][variant_index], member) == 0) {
+                            member_found = true;
+                            break;
+                        }
+                    }
                     break;
                 }
+            }
+            if (!member_found) {
+                diagnostic_error_code_formatted(checker->diag, "E3047", NODE_FILE(checker, node), node->token.line, node->token.column, 0, prefixed_type, member);
             }
             /* Mark module as used */
             for (int mi = 0; mi < checker->import_count; mi++) {
@@ -5722,7 +5732,7 @@ static GrayType *resolve_member_expr(TypeChecker *checker, AstNode *node) {
                     break;
                 }
             }
-            result = is_str_enum ? &TYPE_STRING : &TYPE_INT;
+            result = type_enum(prefixed_type);
             return result;
         }
     }
@@ -5779,12 +5789,10 @@ static GrayType *resolve_member_expr(TypeChecker *checker, AstNode *node) {
         if (is_enum_name(checker, resolved_obj)) {
             /* Rewrite the label to the resolved enum name for codegen */
             obj->data.label.value = resolved_obj;
-            /* Check if this is a string enum and validate member exists */
-            bool is_str_enum = false;
+            /* Validate member exists */
             bool member_found = false;
             for (int enum_index = 0; enum_index < checker->enum_count; enum_index++) {
                 if (strcmp(checker->enum_names[enum_index], resolved_obj) == 0) {
-                    is_str_enum = checker->enum_is_string[enum_index];
                     for (int variant_index = 0; variant_index < checker->enum_value_counts[enum_index]; variant_index++) {
                         if (strcmp(checker->enum_values[enum_index][variant_index], member) == 0) {
                             member_found = true;
@@ -6065,6 +6073,9 @@ static GrayType *resolve_struct_value(TypeChecker *checker, AstNode *node) {
                          strcmp(expected_t->name, val_t->name) != 0)) &&
                        !(is_int_kind(expected_t->kind) && val_t->kind == TK_ENUM) &&
                        !(expected_t->kind == TK_ENUM && is_int_kind(val_t->kind)) &&
+                       /* string enum → string coercion */
+                       !(expected_t->kind == TK_STRING && val_t->kind == TK_ENUM &&
+                         val_t->name && typechecker_enum_is_string(checker, val_t->name)) &&
                        !(expected_t->kind == TK_STRUCT && is_int_kind(val_t->kind)) &&
                        !(is_int_kind(expected_t->kind) && val_t->kind == TK_STRUCT) &&
                        !(expected_t->kind == TK_FLOAT && is_int_kind(val_t->kind)) &&
@@ -8146,11 +8157,13 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
                             /* E3053: cross-enum mismatch — both are TK_ENUM but
                              * from different enum types (e.g. Color vs Dir).
                              * The kind-level check above passes since both are
-                             * TK_ENUM, so we need a name-level comparison. */
+                             * TK_ENUM, so we need a name-level comparison.
+                             * Use display-name comparison so cross-module
+                             * aliases (e.g. types_Status vs Status) unify. */
                             if (actual_et && expected_et &&
                                 actual_et->kind == TK_ENUM && expected_et->kind == TK_ENUM &&
                                 actual_et->name && expected_et->name &&
-                                strcmp(actual_et->name, expected_et->name) != 0) {
+                                !typechecker_same_enum_type(checker, actual_et->name, expected_et->name)) {
                                 diagnostic_error_code_formatted(checker->diag, "E3053", NODE_FILE(checker, arr->data.array_value.elements[enum_index]),
                                     arr->data.array_value.elements[enum_index]->token.line,
                                     arr->data.array_value.elements[enum_index]->token.column, 0, expected_et->name, actual_et->name);
@@ -8590,6 +8603,27 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
                     const char *mfn = fn->data.member.member;
                     char prefixed[MSG_BUF_SIZE];
                     snprintf(prefixed, sizeof(prefixed), "%s_%s", mod, mfn);
+                    FuncSig *sig = find_func(checker, prefixed);
+                    if (sig && sig->return_count > 1) {
+                        Symbol *sym = scope_lookup_local(checker->current_scope,
+                            node->data.var_decl.name);
+                        if (sym) {
+                            sym->ret_types = sig->return_types;
+                            sym->ret_count = sig->return_count;
+                        }
+                    }
+                }
+                /* Triple-chain calls (mod.Type.func); look up mod_Type_func
+                 * and propagate multi-return types for destructuring. */
+                if (fn->kind == NODE_MEMBER_EXPR &&
+                    fn->data.member.object->kind == NODE_MEMBER_EXPR &&
+                    fn->data.member.object->data.member.object->kind == NODE_LABEL) {
+                    const char *mod_raw = fn->data.member.object->data.member.object->data.label.value;
+                    const char *mod = typechecker_resolve_alias(checker, mod_raw);
+                    const char *sname = fn->data.member.object->data.member.member;
+                    const char *mfn = fn->data.member.member;
+                    char prefixed[MSG_BUF_SIZE];
+                    snprintf(prefixed, sizeof(prefixed), "%s_%s_%s", mod, sname, mfn);
                     FuncSig *sig = find_func(checker, prefixed);
                     if (sig && sig->return_count > 1) {
                         Symbol *sym = scope_lookup_local(checker->current_scope,
@@ -9322,10 +9356,12 @@ static void check_statement(TypeChecker *checker, AstNode *node) {
                 diagnostic_error_message(checker->diag, "E3001", msg,
                     NODE_FILE(checker, node), node->token.line, node->token.column, 0);
             }
-            /* Struct-to-struct return name mismatch */
+            /* Struct-to-struct return name mismatch.
+             * Use display-name comparison so cross-module aliases
+             * (e.g. types_Item vs Item) unify correctly. */
             if (ret_t->kind == TK_STRUCT && expected->kind == TK_STRUCT &&
                 ret_t->name && expected->name &&
-                strcmp(ret_t->name, expected->name) != 0) {
+                !typechecker_same_struct_type(checker, ret_t->name, expected->name)) {
                 char *msg = NULL;
                 msg = typechecker_format(checker,
                     "return type mismatch: expected '%s', got '%s'",

--- a/integration-tests/pass/multi-file/cross-module-enum-identity/main.gray
+++ b/integration-tests/pass/multi-file/cross-module-enum-identity/main.gray
@@ -1,0 +1,75 @@
+import and use "./types.gray"
+import "./store.gray"
+
+do main() {
+    mut passed int = 0
+    mut failed int = 0
+
+    // Test 1: enum array initializer with import and use (bare name)
+    mut statuses [Status] = {Status.ACTIVE, Status.INACTIVE}
+    if statuses[0] == Status.ACTIVE {
+        println("  [PASS] enum array init with import and use")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] enum array init with import and use")
+        failed += 1
+    }
+
+    // Test 2: fully qualified enum array initializer
+    mut statuses2 [types.Status] = {types.Status.ACTIVE, types.Status.INACTIVE}
+    if statuses2[1] == Status.INACTIVE {
+        println("  [PASS] fully qualified enum array init")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] fully qualified enum array init")
+        failed += 1
+    }
+
+    // Test 3: enum field comparison across 3 files
+    mut item1 = make_item("first", Status.ACTIVE)
+    mut items [types.Item] = {item1}
+    mut s = store.Store{items: items}
+    if store.Store.check_active(s) {
+        println("  [PASS] enum field comparison across 3 files")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] enum field comparison across 3 files")
+        failed += 1
+    }
+
+    // Test 4: multi-return with cross-module struct type (3 files)
+    mut found_item, found = store.Store.find(s)
+    if found == true {
+        println("  [PASS] multi-return with cross-module type")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] multi-return with cross-module type")
+        failed += 1
+    }
+
+    // Test 5: verify returned item has correct name
+    if found_item.name == "first" {
+        println("  [PASS] multi-return item has correct data")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] multi-return item has correct data: got '${found_item.name}'")
+        failed += 1
+    }
+
+    // Test 6: mixed qualified and unqualified enum usage
+    mut mixed_item = types.make_item("mixed", types.Status.ACTIVE)
+    if mixed_item.status == Status.ACTIVE {
+        println("  [PASS] mixed qualified/unqualified enum comparison")
+        passed += 1
+    } otherwise {
+        println("  [FAIL] mixed qualified/unqualified enum comparison")
+        failed += 1
+    }
+
+    println("Results: ${passed} passed, ${failed} failed")
+    if failed > 0 {
+        println("SOME TESTS FAILED")
+    } otherwise {
+        println("ALL TESTS PASSED")
+    }
+}

--- a/integration-tests/pass/multi-file/cross-module-enum-identity/store.gray
+++ b/integration-tests/pass/multi-file/cross-module-enum-identity/store.gray
@@ -1,0 +1,24 @@
+import and use "./types.gray"
+
+const Store struct {
+    items [types.Item]
+
+    do check_active(self Store) -> bool {
+        for_each item in self.items {
+            if item.status == Status.ACTIVE {
+                return true
+            }
+        }
+        return false
+    }
+
+    do find(self Store) -> (types.Item, bool) {
+        for_each item in self.items {
+            if item.status == Status.ACTIVE {
+                return item, true
+            }
+        }
+        mut empty = Item{name: "", status: Status.INACTIVE}
+        return empty, false
+    }
+}

--- a/integration-tests/pass/multi-file/cross-module-enum-identity/types.gray
+++ b/integration-tests/pass/multi-file/cross-module-enum-identity/types.gray
@@ -1,0 +1,13 @@
+const Status enum {
+    ACTIVE
+    INACTIVE
+}
+
+const Item struct {
+    name string
+    status Status
+}
+
+do make_item(name string, s Status) -> Item {
+    return Item{name: name, status: s}
+}


### PR DESCRIPTION
## Summary
- Fixes 4 cascading failures when enums are used across modules with `import and use` by replacing raw `strcmp` on internal mangled names with display-name-aware comparison functions
- Returns proper enum types from module-qualified variant access (`mod.Enum.VARIANT`) instead of `int`/`string`
- Adds multi-return type propagation for triple-chain struct function calls (`mod.Type.func()`)
- Adds string_enum→string coercion in struct field assignment for consistency with existing enum→int coercion

Closes #2290