### PR TITLE
refactor: clean up xalloc header

### DIFF
--- a/grayc/src/util/xalloc.h
+++ b/grayc/src/util/xalloc.h
@@ -6,7 +6,8 @@
  * Copyright (c) 2025-Present Marshall A Burns
  * Licensed under the MIT License. See LICENSE for details.
  *
- * Confucius40 was here!
+ * Contributors:
+ *  - @confucius40
  */
 
 #ifndef GRAYC_XALLOC_H
@@ -16,10 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define GROW_ARRAY_INIT_CAP 8
-
-static inline void *xmalloc(size_t size)
-{
+static inline void *xmalloc(size_t size) {
     void *ptr = malloc(size);
 
     if (!ptr) {
@@ -30,8 +28,7 @@ static inline void *xmalloc(size_t size)
     return ptr;
 }
 
-static inline void *xcalloc(size_t nmemb, size_t size)
-{
+static inline void *xcalloc(size_t nmemb, size_t size) {
     void *ptr = calloc(nmemb, size);
 
     if (!ptr) {
@@ -42,8 +39,7 @@ static inline void *xcalloc(size_t nmemb, size_t size)
     return ptr;
 }
 
-static inline void *xrealloc(void *ptr, size_t size)
-{
+static inline void *xrealloc(void *ptr, size_t size) {
     void *new_ptr = realloc(ptr, size);
 
     if (!new_ptr) {
@@ -54,8 +50,9 @@ static inline void *xrealloc(void *ptr, size_t size)
     return new_ptr;
 }
 
-static inline char *read_file_to_string(const char *path)
-{
+/* Read an entire seekable file into a malloc'd NUL-terminated string.
+ * Returns NULL on open failure or OOM. */
+static inline char *read_file_to_string(const char *path) {
     FILE *file = fopen(path, "rb");
     if (!file)
         return NULL;
@@ -77,15 +74,17 @@ static inline char *read_file_to_string(const char *path)
     return buffer;
 }
 
+/* Initial capacity for GROW_ARRAY — small enough to avoid waste,
+ * large enough to cover the common case without early resizes. */
+#define GROW_ARRAY_INIT_CAP 8
+
+/* Grow a dynamic array when count reaches capacity.
+ * Doubles capacity (starting from GROW_ARRAY_INIT_CAP), then xrealloc's. */
 #define GROW_ARRAY(arr, count, cap) \
     do { \
         if ((count) >= (cap)) { \
-            (cap) = (cap) \
-                ? (cap) * 2 \
-                : GROW_ARRAY_INIT_CAP; \
-            (arr) = xrealloc( \
-                (arr), \
-                sizeof(*(arr)) * (size_t)(cap)); \
+            (cap) = (cap) ? (cap) * 2 : GROW_ARRAY_INIT_CAP; \
+            (arr) = xrealloc((arr), sizeof(*(arr)) * (size_t)(cap)); \
         } \
     } while (0)
 

--- a/grayc/src/util/xalloc.h
+++ b/grayc/src/util/xalloc.h
@@ -5,6 +5,8 @@
  * Author:  Marshall A Burns (@SchoolyB)
  * Copyright (c) 2025-Present Marshall A Burns
  * Licensed under the MIT License. See LICENSE for details.
+ *
+ * Confucius40 was here!
  */
 
 #ifndef GRAYC_XALLOC_H
@@ -14,63 +16,76 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-static inline void *xrealloc(void *ptr, size_t size) {
-    void *p = realloc(ptr, size);
-    if (!p) {
-        fprintf(stderr, "grayc: out of memory\n");
-        exit(1);
-    }
-    return p;
-}
-
-static inline void *xmalloc(size_t size) {
-    void *p = malloc(size);
-    if (!p) {
-        fprintf(stderr, "grayc: out of memory\n");
-        exit(1);
-    }
-    return p;
-}
-
-static inline void *xcalloc(size_t nmemb, size_t size) {
-    void *p = calloc(nmemb, size);
-    if (!p) {
-        fprintf(stderr, "grayc: out of memory\n");
-        exit(1);
-    }
-    return p;
-}
-
-/* Read an entire seekable file into a malloc'd NUL-terminated string.
- * Returns NULL on open failure or OOM. */
-static inline char *read_file_to_string(const char *path) {
-    FILE *f = fopen(path, "rb");
-    if (!f) return NULL;
-
-    fseek(f, 0, SEEK_END);
-    long size = ftell(f);
-    fseek(f, 0, SEEK_SET);
-
-    char *buf = malloc((size_t)size + 1);
-    if (!buf) { fclose(f); return NULL; }
-
-    size_t n = fread(buf, 1, (size_t)size, f);
-    buf[n] = '\0';
-    fclose(f);
-    return buf;
-}
-
-/* Initial capacity for GROW_ARRAY — small enough to avoid waste,
- * large enough to cover the common case without early resizes. */
 #define GROW_ARRAY_INIT_CAP 8
 
-/* Grow a dynamic array when count reaches capacity.
- * Doubles capacity (starting from GROW_ARRAY_INIT_CAP), then xrealloc's. */
+static inline void *xmalloc(size_t size)
+{
+    void *ptr = malloc(size);
+
+    if (!ptr) {
+        fprintf(stderr, "grayc: out of memory\n");
+        exit(1);
+    }
+
+    return ptr;
+}
+
+static inline void *xcalloc(size_t nmemb, size_t size)
+{
+    void *ptr = calloc(nmemb, size);
+
+    if (!ptr) {
+        fprintf(stderr, "grayc: out of memory\n");
+        exit(1);
+    }
+
+    return ptr;
+}
+
+static inline void *xrealloc(void *ptr, size_t size)
+{
+    void *new_ptr = realloc(ptr, size);
+
+    if (!new_ptr) {
+        fprintf(stderr, "grayc: out of memory\n");
+        exit(1);
+    }
+
+    return new_ptr;
+}
+
+static inline char *read_file_to_string(const char *path)
+{
+    FILE *file = fopen(path, "rb");
+    if (!file)
+        return NULL;
+
+    fseek(file, 0, SEEK_END);
+    long size = ftell(file);
+    fseek(file, 0, SEEK_SET);
+
+    char *buffer = malloc((size_t)size + 1);
+    if (!buffer) {
+        fclose(file);
+        return NULL;
+    }
+
+    size_t n = fread(buffer, 1, (size_t)size, file);
+    buffer[n] = '\0';
+
+    fclose(file);
+    return buffer;
+}
+
 #define GROW_ARRAY(arr, count, cap) \
     do { \
         if ((count) >= (cap)) { \
-            (cap) = (cap) ? (cap) * 2 : GROW_ARRAY_INIT_CAP; \
-            (arr) = xrealloc((arr), sizeof(*(arr)) * (size_t)(cap)); \
+            (cap) = (cap) \
+                ? (cap) * 2 \
+                : GROW_ARRAY_INIT_CAP; \
+            (arr) = xrealloc( \
+                (arr), \
+                sizeof(*(arr)) * (size_t)(cap)); \
         } \
     } while (0)
 


### PR DESCRIPTION
## Summary

* Refactors `xalloc.h` to improve readability and consistency.
* Cleans up the allocation wrapper and `GROW_ARRAY` formatting without changing the existing API or behavior.
* Keeps `read_file_to_string()` behavior unchanged, including returning `NULL` on allocation failure.

## Type of change

* [ ] Bug fix
* [ ] New feature
* [x] Refactor
* [ ] Tests
* [ ] Documentation
* [ ] CI/Build

## Breaking changes

None.

## Checklist

* [ ] `make build` compiles with zero warnings
* [ ] Tests added/updated (unit, integration, or both as appropriate)
* [ ] No `@` before module names in any text (it tags GitHub users)

### If adding user-facing stdlib/builtin/type

* [ ] C implementation in `grayc/src/stdlib/<module>.h` and `.c` (with `@man` block)
* [ ] Typechecker wired: return type, `stdlib_arg_table[]`, `stdlib_arg_type_table[]`, `_using_funcs[]`
* [ ] Codegen wired: `emit_<module>_call()`
* [ ] `STANDARD.md` updated
* [ ] `./scripts/generate_stdlib_man.sh` run and output committed
