### PR TITLE
fix(typechecker): reserve all builtin function names

### DIFF
--- a/grayc/src/util/reserved.h
+++ b/grayc/src/util/reserved.h
@@ -5,6 +5,9 @@
  * Author:  Marshall A Burns (@SchoolyB)
  * Copyright (c) 2025-Present Marshall A Burns
  * Licensed under the MIT License. See LICENSE for details.
+ *
+ * Contributors:
+ *  - @sjh9714
  */
 
 #ifndef GRAY_RESERVED_H
@@ -73,17 +76,22 @@ static const char *const gray_builtin_func_names[] = {
     "eprintln",
     "error",
     "exit",
+    "fields",
     "here",
     "input",
     "len",
+    "new",
     "panic",
     "print",
     "println",
+    "range",
+    "raw",
     "ref",
     "size_of",
     "sleep_ms",
     "sleep_ns",
     "sleep_s",
+    "system",
     "to_char",
     "type_of",
 };

--- a/integration-tests/fail/errors/E5016_fields_shadows_builtin.gray
+++ b/integration-tests/fail/errors/E5016_fields_shadows_builtin.gray
@@ -1,0 +1,11 @@
+// expect-error: E5016
+/*
+ * Error Test: E5016 - 'fields' used as a variable name
+ *
+ * Builtin functions cannot be shadowed by user variables, even when their
+ * names are handled outside the original reserved-name list.
+ */
+
+do main() {
+    mut fields int = 1
+}

--- a/integration-tests/pass/core/raw_string_multiline.gray
+++ b/integration-tests/pass/core/raw_string_multiline.gray
@@ -10,14 +10,14 @@ do main() {
     mut failed int = 0
 
     // Test 1: raw string with newlines
-    mut raw string = `line1
+    mut raw_text string = `line1
 line2
 line3`
-    if len(raw) > 10 {
+    if len(raw_text) > 10 {
         println("  [PASS] raw string with newlines")
         passed += 1
     } otherwise {
-        println("  [FAIL] raw string len: ${len(raw)}")
+        println("  [FAIL] raw string len: ${len(raw_text)}")
         failed += 1
     }
 


### PR DESCRIPTION
## Related issue

Closes #2421

## Summary

- Add the five builtin functions missing from the canonical reserved-name list.
- Add an E5016 regression fixture and rename an existing test local that used `raw`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Tests
- [ ] Documentation
- [ ] CI/Build

## Breaking changes

Declarations that shadow `fields`, `new`, `range`, `raw`, or `system` now fail
with E5016, matching the compiler's treatment of the other builtin functions.

## Checklist

- [ ] `make build` compiles with zero warnings
- [x] Tests added/updated (unit, integration, or both as appropriate)
- [x] No `@` before module names in any text (it tags GitHub users)
- [x] Added yourself to the `Contributors:` section of the header of each source file you changed

## Testing

- `make build` (passed; the existing `grayc/src/stdlib/math.h` `#include_next` warning remains)
- `make test-unit`
- `make test-e2e`
- `make test-integration`
- `make test-go`

Formatting note: clang-format 22 reports existing file-wide formatting
violations in `reserved.h`; the new entries follow the current array style,
the array remains sorted, and `git diff --check` passes.