### PR TITLE
docs: remove obsolete mem.make, mem.free, and mem.size_of rows (#2477)

### DIFF
--- a/STANDARD.md
+++ b/STANDARD.md
@@ -3737,9 +3737,6 @@ Arena-based memory allocation. Compiler-only feature.
 | `usage` | `(arena Arena) -> int` | Return the number of bytes currently used |
 | `init` | `(arena Arena, Type) -> ^Type` | Allocate a zero-initialized value of `Type` in the arena |
 | `alloc` | `(arena Arena, value T) -> ^T` | Allocate a copy of value in the arena |
-| `make` | `(arena Arena, Type) -> ^Type` | Allocate zero-initialized value of Type in arena |
-| `free` | `(arena Arena)` | Free an arena (alias for destroy) |
-| `size_of` | `(Type) -> int` | Size of type in bytes |
 | `raw_copy` | `(dest ptr, src ptr, n int)` | Copy `n` bytes from `src` to `dest` |
 | `zero` | `(p ptr, n int)` | Zero out `n` bytes at `p` |
 | `fill` | `(p ptr, value int, n int)` | Set `n` bytes at `p` to `value` |


### PR DESCRIPTION
## Related issue

Closes #2477

## Summary

<!-- 1-3 bullet points describing what this PR does and why -->

- Remove the unnecessary rows described in the issue. (`mem.make`, `mem.free`, and `mem.size_of` rows from `STANDARD.md`)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Tests
- [x] Documentation
- [ ] CI/Build

## Breaking changes

<!-- Does this PR break any existing behavior? If yes, describe what breaks and why. -->

None.

## Checklist

- [ ] `make build` compiles with zero warnings
- [ ] Tests added/updated (unit, integration, or both as appropriate)
- [ ] No `@` before module names in any text (it tags GitHub users)
- [ ] Added yourself to the `Contributors:` section of the header of each source file you changed

### If adding user-facing stdlib/builtin/type

- [ ] C implementation in `grayc/src/stdlib/<module>.h` and `.c` (with `@man` block)
- [ ] Typechecker wired: return type, `stdlib_arg_table[]`, `stdlib_arg_type_table[]`, `_using_funcs[]`
- [ ] Codegen wired: `emit_<module>_call()`
- [x] `STANDARD.md` updated
- [ ] `./scripts/generate_stdlib_man.sh` run and output committed
