### PR TITLE
chore: remove dead mem.make code and stale mem.size_of comment

### DIFF
--- a/grayc/src/stdlib/mem.h
+++ b/grayc/src/stdlib/mem.h
@@ -136,6 +136,5 @@ void gray_mem_zero(void *ptr, int64_t n);
 /* mem.set(ptr, val, n) — set n bytes to val (memset) */
 void gray_mem_set(void *ptr, int64_t val, int64_t n);
 
-/* mem.size_of(Type) — handled by codegen (sizeof) */
 
 #endif

--- a/grayc/src/typechecker/typechecker.c
+++ b/grayc/src/typechecker/typechecker.c
@@ -2618,13 +2618,6 @@ static GrayType *resolve_stdlib_call(TypeChecker *checker, AstNode *node, const 
             }
         } else if (strcmp(mfn, "alloc") == 0 && node->data.call.arg_count == 2) {
             result = resolve_expression(checker, node->data.call.args[1]);
-        } else if (strcmp(mfn, "make") == 0 && node->data.call.arg_count == 2) {
-            AstNode *type_arg = node->data.call.args[1];
-            if (type_arg->kind == NODE_LABEL) {
-                result = type_pointer(type_arg->data.label.value);
-            } else {
-                result = &TYPE_UNKNOWN;
-            }
         }
     } else if (strcmp(mod, "maps") == 0) {
         if (strcmp(mfn, "get_keys") == 0) {


### PR DESCRIPTION
## Related issue

Closes #2479

## Summary

<!-- 1-3 bullet points describing what this PR does and why -->

- Remove the dead `mem.make` typechecker branch.
- Remove the stale `mem.size_of` comment.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Tests
- [ ] Documentation
- [ ] CI/Build

## Breaking changes

<!-- Does this PR break any existing behavior? If yes, describe what breaks and why. -->

None.

## Checklist

- [ ] `make build` compiles with zero warnings
- [ ] Tests added/updated (unit, integration, or both as appropriate)
- [x] No `@` before module names in any text (it tags GitHub users)
- [ ] Added yourself to the `Contributors:` section of the header of each source file you changed

### If adding user-facing stdlib/builtin/type

- [ ] C implementation in `grayc/src/stdlib/<module>.h` and `.c` (with `@man` block)
- [ ] Typechecker wired: return type, `stdlib_arg_table[]`, `stdlib_arg_type_table[]`, `_using_funcs[]`
- [ ] Codegen wired: `emit_<module>_call()`
- [ ] `STANDARD.md` updated
- [ ] `./scripts/generate_stdlib_man.sh` run and output committed
