### PR TITLE
fix(codegen): evaluate return values before deferred calls

### DIFF
--- a/grayc/src/codegen/codegen.c
+++ b/grayc/src/codegen/codegen.c
@@ -5,6 +5,9 @@
  * Author:  Marshall A Burns (@SchoolyB)
  * Copyright (c) 2025-Present Marshall A Burns
  * Licensed under the MIT License. See LICENSE for details.
+ *
+ * Contributors:
+ *  - @sjh9714
  */
 
 #include "codegen.h"
@@ -10616,9 +10619,6 @@ static void emit_multi_function_return_escape(CodeGen *codegen) {
 }
 
 static void emit_return_statement(CodeGen *codegen, AstNode *node) {
-    /* Emit ensure cleanup before return */
-    emit_ensure_cleanup(codegen);
-
     /* Caller-arena functions have no _scope_mark to restore. */
     bool caller_arena = codegen->current_func &&
                         function_uses_caller_arena(codegen, codegen->current_func);
@@ -10627,6 +10627,7 @@ static void emit_return_statement(CodeGen *codegen, AstNode *node) {
     if (node->data.return_stmt.count > 0 && !node->data.return_stmt.values) {
         emit_indent(codegen);
         emit(codegen, "{ ");
+        emit_ensure_cleanup(codegen);
         emit_scratch_arena_unwind(codegen);
         if (caller_arena) {
             emit(codegen, "gray_exit_func(); return; }\n");
@@ -10649,6 +10650,7 @@ static void emit_return_statement(CodeGen *codegen, AstNode *node) {
                 emit_expression(codegen, node->data.return_stmt.values[i]);
         }
         emit(codegen, "}; ");
+        emit_ensure_cleanup(codegen);
         emit_multi_function_return_escape(codegen);
         emit(codegen, "gray_exit_func(); return _ret; }\n");
     } else if (node->data.return_stmt.count == 1 && codegen->current_func &&
@@ -10678,6 +10680,7 @@ static void emit_return_statement(CodeGen *codegen, AstNode *node) {
                 emit_expression(codegen, node->data.return_stmt.values[0]);
         }
         emit(codegen, "}; ");
+        emit_ensure_cleanup(codegen);
         emit_multi_function_return_escape(codegen);
         emit(codegen, "gray_exit_func(); return _ret; }\n");
     } else if (codegen->current_func &&
@@ -10685,6 +10688,7 @@ static void emit_return_statement(CodeGen *codegen, AstNode *node) {
         /* Void function */
         emit_indent(codegen);
         emit(codegen, "{ ");
+        emit_ensure_cleanup(codegen);
         emit_scratch_arena_unwind(codegen);
         if (caller_arena) {
             emit(codegen, "gray_exit_func(); return; }\n");
@@ -10701,6 +10705,7 @@ static void emit_return_statement(CodeGen *codegen, AstNode *node) {
         if (!emit_bigint_coerced(codegen, ret_bi, node->data.return_stmt.values[0]))
             emit_expression(codegen, node->data.return_stmt.values[0]);
         emit(codegen, "; ");
+        emit_ensure_cleanup(codegen);
         if (codegen->current_func && codegen->current_func->data.func_decl.return_type_count > 0) {
             const char *ret_tn = codegen->current_func->data.func_decl.return_types[0];
             emit_function_return_escape(codegen, ret_tn);
@@ -10715,6 +10720,7 @@ static void emit_return_statement(CodeGen *codegen, AstNode *node) {
             emit_indent(codegen);
             emit_formatted(codegen, "{ __auto_type _ret = %s; ",
                 sanitize_name(codegen->current_func->data.func_decl.return_names[0]));
+            emit_ensure_cleanup(codegen);
             emit_function_return_escape(codegen, codegen->current_func->data.func_decl.return_types[0]);
             emit(codegen, "gray_exit_func(); return _ret; }\n");
         } else {
@@ -10730,6 +10736,7 @@ static void emit_return_statement(CodeGen *codegen, AstNode *node) {
                 }
             }
             emit(codegen, "}; ");
+            emit_ensure_cleanup(codegen);
             emit_multi_function_return_escape(codegen);
             emit(codegen, "gray_exit_func(); return _ret; }\n");
         }
@@ -10737,6 +10744,7 @@ static void emit_return_statement(CodeGen *codegen, AstNode *node) {
         /* Bare return (no value, non-void; shouldn't happen but handle gracefully) */
         emit_indent(codegen);
         emit(codegen, "{ ");
+        emit_ensure_cleanup(codegen);
         emit_scratch_arena_unwind(codegen);
         if (caller_arena) {
             emit(codegen, "gray_exit_func(); return; }\n");

--- a/integration-tests/pass/core/defer_execution_order.gray
+++ b/integration-tests/pass/core/defer_execution_order.gray
@@ -3,6 +3,7 @@
  *  - multiple defers in one function run in last-in-first-out order
  *  - a deferred call's arguments are evaluated when it fires, not when
  *    it is registered
+ *  - return expressions are evaluated before deferred calls run
  *  - defers fire before control returns to the caller, on both the
  *    normal-exit and early-return paths
  *  - each activation's defers are independent across nested calls
@@ -11,9 +12,24 @@
 import @arrays
 
 mut trace [int] = {}
+mut return_counter int = 0
 
 do rec(n int) {
     arrays.append(trace, n)
+}
+
+do increment_return_counter() {
+    return_counter += 1
+}
+
+do next_value() -> int {
+    defer increment_return_counter()
+    return return_counter
+}
+
+do next_pair() -> (int, int) {
+    defer increment_return_counter()
+    return return_counter, return_counter + 10
 }
 
 do lifo() {
@@ -95,6 +111,16 @@ do main() {
         passed += 1
     } otherwise {
         println("[FAIL] nested activations share a defer stack")
+        failed += 1
+    }
+
+    return_counter = 0
+    mut first int = next_value()
+    mut second, offset = next_pair()
+    if first == 0 && second == 1 && offset == 11 && return_counter == 2 {
+        passed += 1
+    } otherwise {
+        println("[FAIL] defer ran before return expressions: ${first}, ${second}, ${offset}")
         failed += 1
     }
 


### PR DESCRIPTION
## Related issue

Closes #2648

## Summary

- Evaluate explicit and named return values before running deferred calls.
- Extend the defer integration test with single- and multi-value return regressions.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Tests
- [ ] Documentation
- [ ] CI/Build

## Breaking changes

None.

## Checklist

- [x] `make build` compiles with zero warnings
- [x] Tests added/updated (unit, integration, or both as appropriate)
- [x] No `@` before module names in any text (it tags GitHub users)
- [x] Added yourself to the `Contributors:` section of the header of each source file you changed

## Testing

- `make build`
- `./gray build integration-tests/pass/core/defer_execution_order.gray -o /tmp/grayscale-2648-defer-test && /tmp/grayscale-2648-defer-test`
- `make test` (1,961 passed)

Formatting note: clang-format 22 reports existing file-wide formatting
violations in `codegen.c`; the inserted cleanup calls follow the surrounding
style, and `git diff --check` passes.